### PR TITLE
Add link for KituraLimiter to the "Other Middlewares" section of the API docs

### DIFF
--- a/en/api/index.md
+++ b/en/api/index.md
@@ -45,6 +45,7 @@ lang: en
 * [Kitura-CORS](http://ibm-swift.github.io/Kitura-CORS)
 * [Kitura-CSRF](http://ibm-swift.github.io/Kitura-CSRF)
 * [Kitura-ResponseTime](http://ibm-swift.github.io/Kitura-ResponseTime)
+* [Kitura-Limiter](https://github.com/teechap/kitura-limiter)
 
 [info]: ../../assets/info-blue.png
 [tip]: ../../assets/lightbulb-yellow.png


### PR DESCRIPTION
Not sure if you guys accept pull requests from people outside IBM, but I made a `SwiftRedis`-based middleware to rate limit client requests. You can check out my repo [here](https://github.com/teechap/kitura-limiter). Is there any interest in merging a link to it on kitura.io? Someone might find it useful 👍