### PR TITLE
IBM-Swift/Kitura#1042 removed the info message about GRMustache on Linux

### DIFF
--- a/en/resources/tutorials/templating.md
+++ b/en/resources/tutorials/templating.md
@@ -27,8 +27,6 @@ Kitura template engines are classes that implement the `TemplateEngine` protocol
 2. [Kitura-MustacheTemplateEngine](https://github.com/IBM-Swift/Kitura-MustacheTemplateEngine).
 3. [Kitura-StencilTemplateEngine](https://github.com/IBM-Swift/Kitura-StencilTemplateEngine).
 
-> ![info] GRMustache is available on macOS. It is also available on Linux starting from Swift 3.1.
-
 You can provide your own Kitura template engine by implementing the `TemplateEngine` protocol from [Kitura-TemplateEngine package](https://github.com/IBM-Swift/Kitura-TemplateEngine/blob/master/Sources/KituraTemplateEngine/TemplateEngine.swift).
 
 ---

--- a/en/resources/tutorials/templating.md
+++ b/en/resources/tutorials/templating.md
@@ -27,7 +27,7 @@ Kitura template engines are classes that implement the `TemplateEngine` protocol
 2. [Kitura-MustacheTemplateEngine](https://github.com/IBM-Swift/Kitura-MustacheTemplateEngine).
 3. [Kitura-StencilTemplateEngine](https://github.com/IBM-Swift/Kitura-StencilTemplateEngine).
 
-> ![info] As of September 2016 GRMustache is available on macOS only and has not been fully ported to Swift 3.0. Please follow the [Kitura-MustacheTemplateEngine](https://github.com/IBM-Swift/Kitura-MustacheTemplateEngine) community for more information.
+> ![info] GRMustache is available on macOS. It is also available on Linux starting from Swift 3.1.
 
 You can provide your own Kitura template engine by implementing the `TemplateEngine` protocol from [Kitura-TemplateEngine package](https://github.com/IBM-Swift/Kitura-TemplateEngine/blob/master/Sources/KituraTemplateEngine/TemplateEngine.swift).
 


### PR DESCRIPTION
available on Linux starting from Swift 3.1