### PR TITLE
extra space removed on tutorials page. fixed #70

### DIFF
--- a/en/resources/tutorials.md
+++ b/en/resources/tutorials.md
@@ -25,7 +25,7 @@ redirect_from: "/resources/tutorial-todo.html"
 
 Learn how to build a back-end for the TodoList web application.
 
-<img src="../../assets/TodoBackend.png" alt="TodoBackend" style="width:100%"/>
+<img src="../../assets/TodoBackend.png" alt="TodoBackend" width="500" style="max-width:100%"/>
 
 ### [Apple FoodTracker](https://github.com/IBM/FoodTrackerBackend)
 

--- a/en/resources/tutorials.md
+++ b/en/resources/tutorials.md
@@ -25,7 +25,7 @@ redirect_from: "/resources/tutorial-todo.html"
 
 Learn how to build a back-end for the TodoList web application.
 
-<img src="../../assets/TodoBackend.png" alt="TodoBackend" width="500"/>
+<img src="../../assets/TodoBackend.png" alt="TodoBackend" style="width:100%"/>
 
 ### [Apple FoodTracker](https://github.com/IBM/FoodTrackerBackend)
 


### PR DESCRIPTION
Extra horizontal space removed from tutorials page.
Screenshot:
![screen shot 2017-11-03 at 18 55 45](https://user-images.githubusercontent.com/20956124/32378090-da5434e6-c0cf-11e7-895d-5a5676bd8900.png)
