### PR TITLE
extra space removed on gettingstarted page.fix #72

### DIFF
--- a/en/starter/gettingstarted.md
+++ b/en/starter/gettingstarted.md
@@ -69,7 +69,7 @@ router.get("/") {
 
 <span class="arrow">&#8227;</span> Edit the Xcode build scheme so it specifies HelloKitura as the Executable (by default it will be set to HelloKitura-Package when you open Xcode).
 
-<img src="../../assets/Edit_Xcode_Build_Schema.png" alt="EditXcodeBuildSchema" width="400"/>
+<img src="../../assets/Edit_Xcode_Build_Schema.png" alt="EditXcodeBuildSchema" style="width:100%"/>
 
 <span class="arrow">&#8227;</span> Click the play button (&#8984;-R) to build and run your new web application.
 

--- a/en/starter/gettingstarted.md
+++ b/en/starter/gettingstarted.md
@@ -69,7 +69,7 @@ router.get("/") {
 
 <span class="arrow">&#8227;</span> Edit the Xcode build scheme so it specifies HelloKitura as the Executable (by default it will be set to HelloKitura-Package when you open Xcode).
 
-<img src="../../assets/Edit_Xcode_Build_Schema.png" alt="EditXcodeBuildSchema" style="width:100%"/>
+<img src="../../assets/Edit_Xcode_Build_Schema.png" alt="EditXcodeBuildSchema" width="400" style="max-width:100%"/>
 
 <span class="arrow">&#8227;</span> Click the play button (&#8984;-R) to build and run your new web application.
 


### PR DESCRIPTION
Extra horizontal space removed from Getting Started page.

**Screenshot:**
![screen shot 2017-11-03 at 20 54 35](https://user-images.githubusercontent.com/20956124/32382686-e86d0f92-c0db-11e7-833f-bef111f1f7cb.png)
