### PR TITLE
Remove deprecated APIs from API reference page

### DIFF
--- a/en/api/index.md
+++ b/en/api/index.md
@@ -56,7 +56,4 @@ lang: en
 * [Kitura-Cache](http://ibm-swift.github.io/Kitura-Cache)
 * [Kitura-Compression](http://ibm-swift.github.io/Kitura-Compression)
 * [Kitura-CORS](http://ibm-swift.github.io/Kitura-CORS)
-* [Kitura-CSRF](http://ibm-swift.github.io/Kitura-CSRF)
-* [Kitura-ResponseTime](http://ibm-swift.github.io/Kitura-ResponseTime)
 * [Kitura-Limiter](https://github.com/teechap/kitura-limiter) (Third-party implemented)
-


### PR DESCRIPTION
The links to the Kitura-CSRF and Kitura-ResponseTime modules, within the 'other middlewares' section of the API reference page, no longer work as these modules have been deprecated and moved from IBM-Swift to IBM-Swift-Sunset.

This PR removes these links from the API reference.