### PR TITLE
Revert "Fix: use new Slack URL"

### DIFF
--- a/_includes/header/header-en.html
+++ b/_includes/header/header-en.html
@@ -33,7 +33,7 @@
 		</div>
 	</div>
         <section id="social">
-		<a href="http://kitura-slack.mybluemix.net/" target="_blank" title="Join the Kitura community on Slack"><img src="/assets/slack.png" alt="Slack icon" width="22" height="22"/></a>
+		<a href="http://slack.kitura.io/" target="_blank" title="Join the Kitura community on Slack"><img src="/assets/slack.png" alt="Slack icon" width="22" height="22"/></a>
 		<a href="http://github.com/IBM-Swift/Kitura" target="_blank" title="Contribute to Kitura on GitHub"><img src="/assets/github.png" alt="GitHub icon" width="26" height="22"/></a>
 		<a href="https://stackoverflow.com/questions/tagged/kitura" target="_blank" title="Ask a Kitura question on StackOverflow"><img src="/assets/stackoverflow.png" alt="StackOverflow icon" width="22" height="22"/></a>
         </section>

--- a/en/starter/gettingstarted.md
+++ b/en/starter/gettingstarted.md
@@ -97,6 +97,6 @@ If you like what you've seen of Kitura so far, star the repository by clicking t
 
 Join in the conversation on Slack.
 
-<a rel="nofollow" href="http://kitura-slack.mybluemix.net/">
+<a rel="nofollow" href="http://swift-at-ibm-slack.mybluemix.net">
 <img src="../../assets/slack.png" alt="Slack" width="50"/>
 </a>

--- a/en/support/support.md
+++ b/en/support/support.md
@@ -25,7 +25,7 @@ Open an issue or get involved and raise a pull request on [GitHub](https://githu
 
 ## Slack
 
-Join the Kitura community on [Slack](http://kitura-slack.mybluemix.net/).
+Join the Kitura community on [Slack](http://swift-at-ibm-slack.mybluemix.net/).
 
 ## Stack Overflow
 
@@ -34,3 +34,4 @@ Use the `kitura` tag to search for questions and answers on [Stack Overflow](htt
 ## Commercial Support for Swift
 
 If you're interested in learning more about this level of support, please contact [jimmail@uk.ibm.com](mailto://jimmail@uk.ibm.com).
+


### PR DESCRIPTION
Reverts IBM-Swift/kitura.io#87
Original Slack URL is now working, so can revert this change.