### PR TITLE
Use slack icon in assets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ If you want to add topics or update existing topics, please open an Issue or cre
 <section class="social-section">
 	<div class="social-link">
 		<a rel="nofollow" href="http://swift-at-ibm-slack.mybluemix.net">
-		<img src="https://developer.ibm.com/swift/wp-content/uploads/sites/69/2018/01/slack-150x150.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
+		<img src="../../../assets/slack.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
 		<p class="social-header">Join the discussion on Slack</p>
 	</div>
 	<div  class="social-link">

--- a/en/guides/guides/codablerouting.md
+++ b/en/guides/guides/codablerouting.md
@@ -173,7 +173,7 @@ The above examples are just fragments of what’s required to use Codable Routin
   <section class="social-section">
   	<div class="social-link">
   		<a rel="nofollow" href="http://swift-at-ibm-slack.mybluemix.net">
-  		<img src="https://developer.ibm.com/swift/wp-content/uploads/sites/69/2018/01/slack-150x150.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
+  		<img src="../../../assets/slack.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
   		<p class="social-header">Join the discussion on Slack</p>
   	</div>
   	<div  class="social-link">

--- a/en/guides/guides/credentials.md
+++ b/en/guides/guides/credentials.md
@@ -90,7 +90,7 @@ That’s the basic setup for web-based Facebook login. Please refer to Kitura-Cr
 <section class="social-section">
 	<div class="social-link">
 		<a rel="nofollow" href="http://swift-at-ibm-slack.mybluemix.net">
-		<img src="https://developer.ibm.com/swift/wp-content/uploads/sites/69/2018/01/slack-150x150.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
+		<img src="../../../assets/slack.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
 		<p class="social-header">Join the discussion on Slack</p>
 	</div>
 	<div  class="social-link">

--- a/en/guides/guides/fastcgi.md
+++ b/en/guides/guides/fastcgi.md
@@ -161,7 +161,7 @@ As in the Nginx examples shown earlier in this document, you may want to configu
 <section class="social-section">
 	<div class="social-link">
 		<a rel="nofollow" href="http://swift-at-ibm-slack.mybluemix.net">
-		<img src="https://developer.ibm.com/swift/wp-content/uploads/sites/69/2018/01/slack-150x150.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
+		<img src="../../../assets/slack.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
 		<p class="social-header">Join the discussion on Slack</p>
 	</div>
 	<div  class="social-link">

--- a/en/guides/guides/parsingrequests.md
+++ b/en/guides/guides/parsingrequests.md
@@ -89,7 +89,7 @@ router.post("/name") { request, response, next in
 <section class="social-section">
 	<div class="social-link">
 		<a rel="nofollow" href="http://swift-at-ibm-slack.mybluemix.net">
-		<img src="https://developer.ibm.com/swift/wp-content/uploads/sites/69/2018/01/slack-150x150.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
+		<img src="../../../assets/slack.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
 		<p class="social-header">Join the discussion on Slack</p>
 	</div>
 	<div  class="social-link">

--- a/en/guides/guides/pathsyntax.md
+++ b/en/guides/guides/pathsyntax.md
@@ -115,7 +115,7 @@ In this case, the path `/(\\d+)` will be matched for `/123`, but not `/` or `/ab
 <section class="social-section">
 	<div class="social-link">
 		<a rel="nofollow" href="http://swift-at-ibm-slack.mybluemix.net">
-		<img src="https://developer.ibm.com/swift/wp-content/uploads/sites/69/2018/01/slack-150x150.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
+		<img src="../../../assets/slack.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
 		<p class="social-header">Join the discussion on Slack</p>
 	</div>
 	<div  class="social-link">

--- a/en/guides/guides/responsehandlers.md
+++ b/en/guides/guides/responsehandlers.md
@@ -83,7 +83,7 @@ A GET request to localhost:8080 will return "Welcome" and a request to localhost
 <section class="social-section">
 	<div class="social-link">
 		<a rel="nofollow" href="http://swift-at-ibm-slack.mybluemix.net">
-		<img src="https://developer.ibm.com/swift/wp-content/uploads/sites/69/2018/01/slack-150x150.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
+		<img src="../../../assets/slack.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
 		<p class="social-header">Join the discussion on Slack</p>
 	</div>
 	<div  class="social-link">

--- a/en/guides/guides/sessions.md
+++ b/en/guides/guides/sessions.md
@@ -261,7 +261,7 @@ To stop all data being lost on server restart, you can use [Kitura-Session-Redis
 <section class="social-section">
 	<div class="social-link">
 		<a rel="nofollow" href="http://swift-at-ibm-slack.mybluemix.net">
-		<img src="https://developer.ibm.com/swift/wp-content/uploads/sites/69/2018/01/slack-150x150.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
+		<img src="../../../assets/slack.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
 		<p class="social-header">Join the discussion on Slack</p>
 	</div>
 	<div  class="social-link">

--- a/en/guides/guides/ssl.md
+++ b/en/guides/guides/ssl.md
@@ -142,7 +142,7 @@ Notice the `https` in your URL!  You are running Kitura with TLS! This means tha
 <section class="social-section">
 	<div class="social-link">
 		<a rel="nofollow" href="http://swift-at-ibm-slack.mybluemix.net">
-		<img src="https://developer.ibm.com/swift/wp-content/uploads/sites/69/2018/01/slack-150x150.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
+		<img src="../../../assets/slack.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
 		<p class="social-header">Join the discussion on Slack</p>
 	</div>
 	<div  class="social-link">

--- a/en/guides/guides/staticcontent.md
+++ b/en/guides/guides/staticcontent.md
@@ -45,7 +45,7 @@ router.all("/my/path", middleware: StaticFileServer(path: "./files"))
 <section class="social-section">
 	<div class="social-link">
 		<a rel="nofollow" href="http://swift-at-ibm-slack.mybluemix.net">
-		<img src="https://developer.ibm.com/swift/wp-content/uploads/sites/69/2018/01/slack-150x150.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
+		<img src="../../../assets/slack.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
 		<p class="social-header">Join the discussion on Slack</p>
 	</div>
 	<div  class="social-link">

--- a/en/guides/guides/swiftmetrics.md
+++ b/en/guides/guides/swiftmetrics.md
@@ -79,7 +79,7 @@ Kitura.addHTTPServer(onPort: 8080, with: router)
 <section class="social-section">
 	<div class="social-link">
 		<a rel="nofollow" href="http://swift-at-ibm-slack.mybluemix.net">
-		<img src="https://developer.ibm.com/swift/wp-content/uploads/sites/69/2018/01/slack-150x150.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
+		<img src="../../../assets/slack.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
 		<p class="social-header">Join the discussion on Slack</p>
 	</div>
 	<div  class="social-link">

--- a/en/guides/guides/templating.md
+++ b/en/guides/guides/templating.md
@@ -537,7 +537,7 @@ If you'd like to see a Stencil template engine in use in an iOS app checkout our
 <section class="social-section">
 	<div class="social-link">
 		<a rel="nofollow" href="http://swift-at-ibm-slack.mybluemix.net">
-		<img src="https://developer.ibm.com/swift/wp-content/uploads/sites/69/2018/01/slack-150x150.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
+		<img src="../../../assets/slack.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
 		<p class="social-header">Join the discussion on Slack</p>
 	</div>
 	<div  class="social-link">

--- a/en/guides/guides/tutorial_todo.md
+++ b/en/guides/guides/tutorial_todo.md
@@ -329,7 +329,7 @@ This concludes this tutorial. Keep in mind that Kitura is under active developme
 <section class="social-section">
 	<div class="social-link">
 		<a rel="nofollow" href="http://swift-at-ibm-slack.mybluemix.net">
-		<img src="https://developer.ibm.com/swift/wp-content/uploads/sites/69/2018/01/slack-150x150.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
+		<img src="../../../assets/slack.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
 		<p class="social-header">Join the discussion on Slack</p>
 	</div>
 	<div  class="social-link">

--- a/en/starter/leveragedocker.md
+++ b/en/starter/leveragedocker.md
@@ -83,7 +83,7 @@ These are the steps to expose Kitura's port in a Docker container to the host (e
 <section class="social-section">
 	<div class="social-link">
 		<a rel="nofollow" href="http://swift-at-ibm-slack.mybluemix.net">
-		<img src="https://developer.ibm.com/swift/wp-content/uploads/sites/69/2018/01/slack-150x150.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
+		<img src="../../../assets/slack.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
 		<p class="social-header">Join the discussion on Slack</p>
 	</div>
 	<div  class="social-link">

--- a/en/starter/xcode.md
+++ b/en/starter/xcode.md
@@ -87,7 +87,7 @@ For Kitura app:
 <section class="social-section">
 	<div class="social-link">
 		<a rel="nofollow" href="http://swift-at-ibm-slack.mybluemix.net">
-		<img src="https://developer.ibm.com/swift/wp-content/uploads/sites/69/2018/01/slack-150x150.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
+		<img src="../../../assets/slack.png" alt="Slack Logo" width="60" height="60" class="social-image"/></a>
 		<p class="social-header">Join the discussion on Slack</p>
 	</div>
 	<div  class="social-link">


### PR DESCRIPTION
Currently we link to an external location for the slack icon, this PR ensures we're using the slack icon from the `assets` directory. 

Also updates the contributing guide with these changes. 