### PR TITLE
Add Swift-Kuery-ORM to API reference

### DIFF
--- a/en/api/index.md
+++ b/en/api/index.md
@@ -23,6 +23,7 @@ lang: en
 * [HeliumLogger](http://ibm-swift.github.io/HeliumLogger/)
 
 ## Client
+
 * [KituraKit](https://ibm-swift.github.io/KituraKit)
 
 ## Credentials
@@ -38,6 +39,7 @@ lang: en
 
 * [Kitura-Redis](http://ibm-swift.github.io/Kitura-redis/)
 * [Swift-Kuery](http://ibm-swift.github.io/Swift-Kuery/)
+* [Swift-Kuery-ORM](http://ibm-swift.github.io/Swift-Kuery-ORM/)
 
 ## Sessions
 
@@ -45,6 +47,7 @@ lang: en
 * [Kitura-Session-Redis](http://ibm-swift.github.io/Kitura-Session-Redis)
 
 ## Communications
+
 * [Kitura-WebSocket](http://ibm-swift.github.io/Kitura-WebSocket)
 
 ## Templating


### PR DESCRIPTION
Now that we have API reference doc for Swift-Kuery-ORM we should link to it from kitura.io.  NB. this has been tested locally and the published github pages link worked fine.