### PR TITLE
Stop nav from scrolling

### DIFF
--- a/css/mobile_guides.css
+++ b/css/mobile_guides.css
@@ -1,6 +1,10 @@
 /**
     Header Styling
 */
+header {
+  position: relative;
+}
+
 .header-container {
   flex-direction: column;
 }


### PR DESCRIPTION
When on mobile the nav bar should scroll down the page with you as it takes up to much of the screen. 

This PR prevents the nav bar from scrolling when viewing on smaller screens. 