### PR TITLE
Add StencilTemplateEngine APIDoc

### DIFF
--- a/packages.html
+++ b/packages.html
@@ -180,7 +180,7 @@
           <h3><a href="https://github.com/IBM-Swift/Kitura-MustacheTemplateEngine">Kitura-MustacheTemplateEngine</a></h3>
           <h4>Template engine for Kitura that uses Mustache based templates.</h4>
 
-          <h3><a href="https://github.com/IBM-Swift/Kitura-StencilTemplateEngine">Kitura-StencilTemplateEngine</a></h3>
+          <h3><a href="https://github.com/IBM-Swift/Kitura-StencilTemplateEngine">Kitura-StencilTemplateEngine</a></h3><a href="https://ibm-swift.github.io/Kitura-StencilTemplateEngine/"><h5>API</h5></a>
           <h4>Template engine for Kitura that uses Stencil based templates.</h4>
       </div>
       <div class="backend card">


### PR DESCRIPTION
Added in the APIDoc for the Kitura-StencilTemplateEngine - this has been tested locally.