### PR TITLE
Add API button to home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,6 +98,7 @@ Kitura.run()
     <section class="button-section">
       <button class="button" type="button" name="start-button" onclick="window.open('guides/gettingstarted.html', '_self')">>  GET STARTED</button>
       <button class="button slack-button" type="button" name="slack-button" onclick="window.open('http://slack.kitura.io/')"><img class="slack-icon" src="assets/slack-icon.png" alt="Slack Icon">SLACK</button>
+      <button class="button" type="button" name="slack-button" onclick="window.location.href='packages.html#all'"><img class="slack-icon" src="assets/api-icon.png" alt="API Icon">API DOCS</button>
     </section>
 
     <div class="blogs-heading-section">


### PR DESCRIPTION
This PR adds the API button found on the Learn page to home page as well. The following image shows what this would look like: 

<img width="1440" alt="screen shot 2018-06-20 at 07 22 26" src="https://user-images.githubusercontent.com/25609923/41642003-fc2ade92-745e-11e8-92a1-4f1f68fcef22.png">
