### PR TITLE
Add htmlforms guide

### DIFF
--- a/guides/routing/htmlforms.html
+++ b/guides/routing/htmlforms.html
@@ -1,0 +1,239 @@
+<html lang="en">
+
+<head>
+  <title>Learn - HTML forms: parsing URL encoded data</title>
+  <link rel="icon" type="image/png" href="../../assets/favicon-32x32.png" sizes="32x32" />
+  <link rel="icon" type="image/png" href="../../assets/favicon-16x16.png" sizes="16x16" />
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script src="../../scripts/prism.js"></script>
+  <link rel="stylesheet" href="../../css/reset.css">
+  <link rel="stylesheet" href="../../css/main.css">
+  <link rel="stylesheet" href="../../css/guides.css">
+  <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/mobile_guides.css">
+</head>
+
+<header>
+  <div class="header-container">
+    <div class="header-main">
+      <a class="home-link" href="../../index.html">
+        <img class="header-logo" src="../../assets/kitura-logo.png" alt="Kitura logo">
+        <h1 class="header-title">KITURA</h1>
+      </a>
+    </div>
+    <nav class="header-nav">
+      <a class="header-link active-nav" href="../../learn.html">LEARN</a>
+      <a class="header-link" href="../../packages.html">PACKAGES</a>
+      <a class="header-link" href="../../events.html">EVENTS</a>
+      <a class="header-link" href="../../help.html">HELP</a>
+    </nav>
+  </div>
+</header>
+<body>
+  <section class="guide-content">
+    <div class="title-block">
+        <img width="480px" src="../../assets/Kitura.svg" alt="Kitura Logo">
+      <h1>HTML Forms: Parsing URL Encoded Data</h1>
+    </div>
+    <ul class="contents"> Contents
+      <li><a href="#kitura-server">Create a Kitura Server</a></li>
+      <li><a href="#html-form">Create the HTML Form</a></li>
+      <li><a href="#form-model">Create the Form Model</a></li>
+      <li><a href="#codable-routes">Set up Codable Routes</a></li>
+      <li><a href="#raw-routes">Set up Raw Routes</a></li>
+    </ul>
+
+
+    <h2><a name="kitura-server" style="padding-top: 100px;"></a>Create a Kitura Server</h2>
+
+    <p class="sentence">First we need a Kitura server to add our routes to. If you are working with an existing project you can skip this section.</p>
+    <p class="sentence">Kitura has a command-line interface which provides us with utilities for quickly creating a Kitura server.</p>
+    <p class="sentence">Once we've installed the Kitura command-line interface, open a terminal window and run the following:</p>
+    <p class="sentence">1. Create a directory:</p>
+    <pre><code class="language-swift">mkdir ~/HTMLForms</code></pre>
+    <p class="sentence">2. Change to the new directory:</p>
+    <pre><code class="language-swift">cd ~/HTMLForms</code></pre>
+    <p class="sentence">Create the Kitura server:</p>
+    <pre><code>kitura init</code></pre>
+    <p class="sentence">kitura init creates, builds and generates a starter Kitura Xcode project and will take a couple of minutes to complete. This includes best-practice implementations of health checking and monitoring as well as configuration files to allow easy deployment to a Docker container, a Kubernetes cluster, or the IBM Cloud.</p>
+    <p class="sentence">Now we're ready create our HTML form!</p>
+
+
+    <h2><a name="html-form" style="padding-top: 100px;"></a>Create the HTML Form</h2>
+
+    <p class="sentence">Webpages use <a href="https://www.w3schools.com/html/html_forms.asp">HTML forms</a> to take a user's input and send it as an HTTP request.</p>
+    <p class="sentence">The form data can be sent via a HTTP GET request. In this case, the data gets appended to the url as a query string query string consisting of “key=value” pairs, separated by the “&amp” symbol.</p>
+    <p class="sentence">A example HTML form GET request could be:</p>
+    <pre><code class="language-swift">http://localhost.com/form?name=Andy&age=&isDeveloper=true</code></pre>
+    <p class="sentence">Using a GET request allows users to bookmark the result and is better for non-secure data</p>
+    <p class="sentence">The form data can also be sent via a HTTP POST request. In this case, the data is sent with the content-type header "application/x-www-form-urlencoded". This indicates that the body of the request is a query string.</p>
+    <p class="sentence">The data from above sent as a POST request, would be:</p>
+    <pre>POST / HTTP/1.1
+Host: http://localhost:8080/form
+Content-Type: application/x-www-form-urlencoded
+Content-Length: 31
+name=Andy&age=&isDeveloper=true</pre>
+    <p class="sentence">Use POST whenever you are working with sensitive or personal information.</p>
+    <p class="sentence">We will now create an HTML page containing get and post forms</p>
+    <p class="sentence">Create a public directory:</p>
+    <pre><code class="language-swift">mkdir ~/HTMLForms/public</code></pre>
+    <p class="sentence">Move to your new directory:</p>
+    <pre><code class="language-swift">cd ~/HTMLForms/public</code></pre>
+    <p class="sentence">Create an HTML file:</p>
+    <pre><code class="language-swift">touch formwebpage.html</code></pre>
+    <p class="sentence">Open your HTML file:</p>
+    <pre><code class="language-swift">open -a Xcode.app formwebpage.html</code></pre>
+    <p class="sentence">Copy in the following HTML: </p>
+    <pre>&lt;!DOCTYPE html&gt;
+&lt;html&gt;
+&lt;body&gt;
+&lt;h2&gt;URL Encoded Forms&lt;/h2&gt;
+
+&lt;h4&gt;Post to Codable route&lt;/h4&gt;
+&lt;form action="codable" method="post" enctype="application/x-www-form-urlencoded" target="redirect"&gt;
+    Name: &lt;input type="text" name="name" required="required"&gt;&lt;br&gt;
+    Age: &lt;input type="number" name="age" &gt;&lt;br&gt;
+    isDeveloper:&lt;input type="checkbox" name="isDeveloper" value="true"&gt;&lt;br&gt;
+    &lt;input type="submit" value="Submit"&gt;
+&lt;/form&gt;
+
+&lt;h4&gt;Get to Codable route&lt;/h4&gt;
+&lt;form action="codable" method="get" enctype="application/x-www-form-urlencoded" target="redirect"&gt;
+    Name: &lt;input type="text" name="name" required="required"&gt;&lt;br&gt;
+    Age: &lt;input type="number" name="age" &gt;&lt;br&gt;
+    isDeveloper:&lt;input type="checkbox" name="isDeveloper" value="true"&gt;&lt;br&gt;
+    &lt;input type="submit" value="Submit"&gt;
+&lt;/form&gt;
+
+&lt;h4&gt;Post to Raw route&lt;/h4&gt;
+&lt;form action="raw" method="post" enctype="application/x-www-form-urlencoded" target="redirect"&gt;
+    Name: &lt;input type="text" name="name" required="required"&gt;&lt;br&gt;
+    Age: &lt;input type="number" name="age"&gt;&lt;br&gt;
+    isDeveloper:&lt;input type="checkbox" name="isDeveloper" value="true"&gt;&lt;br&gt;
+    &lt;input type="submit" value="Submit"&gt;
+&lt;/form&gt;
+
+&lt;h4&gt;Get to Raw route&lt;/h4&gt;
+&lt;form action="raw" method="get" enctype="application/x-www-form-urlencoded" target="redirect"&gt;
+    Name: &lt;input type="text" name="name" required="required"&gt;&lt;br&gt;
+    Age: &lt;input type="number" name="age" &gt;&lt;br&gt;
+    isDeveloper:&lt;input type="checkbox" name="isDeveloper" value="true"&gt;&lt;br&gt;
+    &lt;input type="submit" value="Submit"&gt;
+&lt;/form&gt;
+
+
+&lt;iframe name="redirect" style="display:none;"&gt;&lt;/iframe&gt;
+&lt;/body&gt;
+&lt;/html&gt;</pre>
+    <p class="sentence">This HTML will make a simple page with four HTML forms. These forms contain:</p>
+    <ul>
+      <li>"Name": a required text input</li>
+      <li>"Age": an optional number input</li>
+      <li>"isDeveloper": A checkbox, which sends "true" if checked</li>
+    </ul>
+    <p class="sentence">We will serve this page using a "StaticFileServer".</p>
+    <p class="sentence">1. Open your Xcode project:</p>
+    <pre><code class="language-swift">open ~/HTMLForms/HTMLForms.xcodeproj</code></pre>
+    <p class="sentence">2. Open Sources > Application > Application.swift</p>
+    <p class="sentence">3. Inside the postInit function, add the static file server middleware: </p>
+    <pre><code class="language-swift">router.get("/", middleware: StaticFileServer())</code></pre>
+    <p class="sentence">4. In the top left of Xcode is a toolbox icon. Click this and change the scheme from "HTMLForms-Package" to "HTMLForms".</p>
+    <p class="sentence">5. Run the server and go to: <a href="localhost:8080/formwebpage.html">localhost:8080/formwebpage.html</a></p>
+    <p class="sentence">You should see a simple HTML page with four HTML forms. These will send the input data to our server. Now we need to create the server routes that receive this data.</p>
+
+    <h2><a name="form-model" style="padding-top: 100px;"></a>Create the Form Model</h2>
+
+    <p class="sentence">The Kitura server works directly with Swift value types, therefore we need to contruct a value type to use.
+    <p class="sentence">It's good practice to keep value types (in this case models) and logic separated. Create a new file, to contain the models, called Models.swift as follows:</p>
+    <ul>
+      <li>1. In Xcode right click on the Application folder and select New File.</li>
+      <li>2. Select Swift File in the UI pop up and click next.</li>
+      <li>3. In the Save As field, name the file Models.swift.</li>
+      <li>4. Ensure Group is Application and target is Application.</li>
+      <li>5. Click Create to create the file.</li>
+    </ul>
+    <p class="sentence">For now, let's create a very simple model:</p>
+    <p class="sentence">1. Open Models.swift</p>
+    <p class="sentence">2. Copy in the following code:</p>
+    <pre><code class="language-swift">struct InputForm: Codable, QueryParams {
+    let name: String
+    let age: Int?
+    let isDeveloper: Bool
+}</code></pre>
+    <p class="sentence">This provides a simple representation of a data we will recieve from our form. We marked it as Codable so it can be used in Codable routes and as QueryParams so it can be decoded from query parameters on a GET request.</p>
+    <p class="sentence">If the forms "age" field is empty, it will send the empty string in the query and Kitura will decode the value to nil. If the forms "isDeveloper" field is empty, it will send the empty string in the query and Kitura will decode the value to false.
+    <p class="sentence">Now we have a model we can use, we can create our routes!</p>
+
+
+    <h2><a name="codable-routes" style="padding-top: 100px;"></a>Setup the Codable Routes</h2>
+    <p class="sentence">We will now create a <a href="https://www.kitura.io/guides/routing/codablerouting.html">Codable route</a> to recieve the POST request from an HTML form.</p>
+    <p class="sentence">1. Inside "postInit", Register the route handler:</p>
+    <pre><code class="language-swift">router.post("/codable", handler: postFormHandler)</code></pre>
+    <p class="sentence">2. After the "postInit" function, add your "postFormHandler" function:
+    <pre><code class="language-swift">func postFormHandler(user: User, respondWith: (User?, RequestError?) -> Void) {
+    print("Codable POST route: \(user.name), is \(user.age) years old")
+    if(user.isDeveloper) { print("and they are a developer") }
+    respondWith(user, nil)
+}</code></pre>
+    <p class="sentence">3. Go to <a href="localhost:8080/formwebpage.html">localhost:8080/formwebpage.html</a> and send the "Post to Codable route" form. In the Xcode logger you should see our printed message with the form data.</p>
+
+    <p class="sentence">We will now create a <a href="https://www.kitura.io/guides/routing/codablerouting.html">Codable route</a> to recieve the GET request from an HTML form.</p>
+    <p class="sentence">4. Inside "postInit", Register the route handler:</p>
+    <pre><code class="language-swift">router.get("/codable", handler: getFormHandler)</code></pre>
+    <p class="sentence">5. After the "postInit" function, add your "getFormHandler" function:
+    <pre><code class="language-swift">func getFormHandler(user: User, respondWith: (User?, RequestError?) -> Void) {
+    print("Codable GET route: \(user.name), is \(user.age) years old")
+    if(user.isDeveloper) { print("and they are a developer") }
+    respondWith(user, nil)
+}</code></pre>
+    <p class="sentence">6. Go to <a href="localhost:8080/formwebpage.html">localhost:8080/formwebpage.html</a> and send the "Get to Codable route" form. In the Xcode logger you should see our printed message with the form data.</p>
+
+
+    <h2><a name="raw-routes" style="padding-top: 100px;"></a>Setup the Raw Routes</h2>
+    <p class="sentence">We will now create a Raw route to recieve the POST request from an HTML form.</p>
+    <p class="sentence">1. Inside "postInit", Register the Raw POST route:</p>
+    <pre><code class="language-swift">router.post("/raw") { request, response, next in
+    guard let user = try? request.read(as: User.self)
+    else {
+        return try response.status(.unprocessableEntity).end()
+    }
+    print("Raw POST route: \(user.name), is \(user.age) years old")
+    if(user.isDeveloper) { print("and they are a developer") }
+    response.status(.created).send(json: user)
+    next()
+}</code></pre>
+    <p class="sentence">This will function the same as the Codable POST route above, to receive and parse the HTML form.</p>
+    <p class="sentence">2. Go to <a href="localhost:8080/formwebpage.html">localhost:8080/formwebpage.html</a> and send the "POST to Raw route" form. In the Xcode logger you should see our printed message with the form data.</p>
+    <p class="sentence">3. After the Raw POST route, Register the Raw GET route:</p>
+    <pre><code class="language-swift">router.get("/raw") { request, response, next in
+    guard let user = getQueryParameters(as: User.self)
+    else {
+        return try response.status(.unprocessableEntity).end()
+    }
+    print("Raw GET route: \(user.name), is \(user.age) years old")
+    if(user.isDeveloper) { print("and they are a developer") }
+    response.status(.created).send(json: user)
+    next()
+}
+}</code></pre>
+    <p class="sentence">4. Go to <a href="localhost:8080/formwebpage.html">localhost:8080/formwebpage.html</a> and send the "GET to Raw route" form. In the Xcode logger you should see our printed message with the form data.</p>
+    <p class="sentence">This will function the same as the Codable GET route above, to receive and parse the HTML form.</p>
+    </section>
+  <section class="slack-help">
+    <a href="http://slack.kitura.io/">
+      <img width="80px" src="../../assets/slack-icon.png" alt="Slack icon">
+      <h2>NEED HELP?</h2>
+      <h2>MESSAGE US ON SLACK.</h2>
+    </a>
+  </section>
+</body>
+<footer>
+
+  <nav class="footer-nav">
+    <a class="footer-link" href="https://forums.swift.org/c/related-projects/kitura">FORUMS</a>
+    <a class="footer-link" href="https://github.com/IBM-Swift/Kitura"><img class="footer-logo" src="../../assets/Kitura-White.svg" alt="Kitura logo"></a>
+    <a class="footer-link" href="https://developer.ibm.com/swift/blogs/">BLOGS</a>
+  </nav>
+</footer>
+</html>


### PR DESCRIPTION
Adding a guide for parsing HTML forms. This follows on from this [blog post](https://developer.ibm.com/swift/2018/05/02/url-encoded-forms-kitura/) and uses a similar example.

Since this blog post we have added support for optional with html forms in this [pull request](https://github.com/IBM-Swift/KituraContracts/pull/26) which is reflected in the guide.

This also still needs to be added to the guides section.