### PR TITLE
Add remaining CLI docs to website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .DS_Store
 _site
-

--- a/css/main.css
+++ b/css/main.css
@@ -478,7 +478,7 @@ footer {
 }
 
 .guides-list {
-    max-width: 1200px;
+    max-width: 1500px;
     margin: 0 auto;
     border-radius: 15px;
     box-shadow: 3px 3px 15px #606060;

--- a/guides/kituracli/gettingstarted.html
+++ b/guides/kituracli/gettingstarted.html
@@ -36,7 +36,14 @@
         <img width="480px" src="../../assets/Kitura.svg" alt="Kitura Logo">
       <h1>USING KITURA CREATE</h1>
     </div>
-    <h2>OVERVIEW</h2>
+    <ul class="contents"> Contents
+      <li><a href="#overview">Overview</a></li>
+      <li><a href="#installation">Installation</a></li>
+      <li><a href="#getting-started">Getting Started</a></li>
+      <li><a href="#core-concepts">Core Concepts</a></li>
+      <li><a href="#prompt-reference">Prompt Reference</a></li>
+    </ul>
+    <h2><a name="overview"></a>OVERVIEW</h2>
     <p>The kitura create command is a command-line tool that provides a guided question-and-answer way to create Kitura Swift applications.</p>
     <p>The generator supports two different ways to generate an application: scaffolding a starter and generating a CRUD application.</p>
     <h3>Scaffolding a starter</h2>
@@ -44,7 +51,7 @@
     <p>You can select from a number of different options presented by the generator to define extra content to be included in the resulting application. For example, these include things like adding the boilerplate for serving static files and creating connections to databases.</p>
     <h3>Generating a CRUD application</h2>
     <p>A CRUD (Create-Read-Update-Delete) application is one where you provide a description of a data model and the generator creates application code for a REST webservice that will provide endpoints to perform create, read, update and delete operations for data matching that data model. In the current version of the generator, most of the generated CRUD application is not open for modification or extension—expect this to change in a future version to allow for more flexibility.</p>
-    <h2>Installation</h2>
+    <h2><a name="installation"></a>Installation</h2>
     <h3>macOS</h3>
     <p>Follow the <a href="../gettingstarted.html">Getting Started</a>.</p>
     <h3>Ubuntu Linux</h3>
@@ -72,7 +79,7 @@
       </ul>
     </blockquote>
 
-    <h2>Getting Started</h2>
+    <h2><a name="getting-started"></a>Getting Started</h2>
     <p>First, run the Kitura application generation (see Command line tools):</p>
     <pre><code class="language-swift">kitura create</code></pre>
     <p>Enter swiftserver-getting-started as the application name.</p>
@@ -149,7 +156,7 @@ Your Kitura based server is up and running!</code></pre>
       <li>2. Create web content in the public directory.</li>
       <li>3. View the embedded metrics dashboard on http://localhost:8080/swiftmetrics-dash.</li>
     </ul>
-    <h2>CORE CONCEPTS</h2>
+    <h2><a name="core-concepts"></a>Core Concepts</h2>
     <p>The kitura create command creates a Kitura Swift application based on the project type, capabilities and services you select. To do this, use the command-line tools provided by installing the generator.</p>
     <h3>Project type</h3>
     <p>The project type defines whether the generated application is a scaffold or CRUD application.</p>
@@ -299,6 +306,146 @@ docker build -t myapp-build -f Dockerfile-tools .</code></pre>
     <p>Boilerplate code for creating a client object for the Push Notifications API is included inside Sources/Application/Application.swift as an internal variable available for use anywhere in the Application module.</p>
     <p>The connection details for this client are loaded by the configuration code and are passed to the Push Notifications client in the boilerplate code.</p>
     <p>More information about the Push Notifications Service can be found in the README.</p>
+    <h2><a name="prompt-reference"></a>Prompt Reference</h2>
+    <p>The following sections describe the prompts provided by the application generator.</p>
+    <h3>Application name prompt</h3>
+    <p>If you did not supply an application name as an argument, the application generator will ask the name you would like to use for your application:</p>
+    <code><pre>What's the name of your application? (currentDirectory)</pre></code>
+    <p>The default value is the name of the current working directory.</p>
+    <p>The application name you enter must satisfy the following constraints:</p>
+    <ul>
+      <li>Must not start with a .</li>
+      <li>Must not contain whitespace characters</li>
+      <li>Must not contain any of the following characters: /@+%:</li>
+      <li>Must not contain characters reserved in URIs</li>
+      <li>Must not be node_modules</li>
+      <li>Must not be favicon.ico</li>
+    </ul>
+    <h3>Application directory prompt</h3>
+    <p>The application generator will ask the name of the directory you would like to use for your application:</p>
+    <code><pre>Enter the name of the directory to contain the project: (applicationName)</pre></code>
+    <p>The default value is the name of the application.</p>
+    <p>If the directory name is the same as the current directory, then the generator will assume you want to create the project in direcly in the current directory rather than creating a subdirectory of the same name.</p>
+    <p>The application directory you enter must satisfy the following constraints:</p>
+    <ul>
+      <li>Must not contain whitespace characters</li>
+      <li>Must not contain any of the following characters: /@+%:</li>
+      <li>Must not contain characters reserved in URIs</li>
+    </ul>
+    <h3>Project type prompt</h3>
+    <p>The application generator will ask which type of project you would like to create, offering two options:</p>
+    <code>
+      <pre>
+  Select type of project: (Use arrow keys)
+❯ Scaffold a starter
+  Generate a CRUD application</pre>
+    </code>
+    <p>The Scaffold a starter option will direct the generator to create a scaffolded application providing boilerplate code and application structure to which your application logic can be added.</p>
+    <p>The Generate a CRUD application option will direct the generator to create a CRUD application on top of which a data model can be defined which will automatically be mapped to REST endpoints for create, read and update operations. At present the code for this type of application is not very customizable aside from modifying the data model.</p>
+    <h2>Application pattern prompt</h2>
+    <p>For scaffolded applications, the application generator will ask which application pattern you want to select, offering three options:</p>
+    <code>
+      <pre>
+  Select capability presets for application pattern: (Use arrow keys)
+❯ Basic
+  Web</pre>
+    </code>
+    <p>The application pattern defines the capabilities that are selected by default in the subsequent capabilities prompt. They are presets and the capabilities they suggest can be modified as required.</p>
+    <h4>Basic pattern</h4>
+    <p>The Basic pattern is intended for any type of application, making the fewest assumptions about the application logic. Selecting this pattern will result in the following defaults for the capabilities prompt:</p>
+    <code>
+      <pre>
+◯ Static web file serving
+◯ Swagger UI
+◉ Embedded metrics dashboard
+◉ Docker files</pre>
+    </code>
+    <h4>Web pattern</h4>
+    <p>The Web pattern is intended for an application that needs to provide a web server hosting static files. Selecting this pattern will result in the following defaults for the capabilities prompt:</p>
+    <code>
+      <pre>
+◉ Static web file serving
+◯ Swagger UI
+◉ Embedded metrics dashboard
+◉ Docker files</pre>
+    </code>
+    <h4>BFF pattern</h4>
+    <p>The Backend-for-frontend (BFF) pattern is intended for an application that provides a microservice intended for consumption by a client application (for example, a web or mobile application). Selecting this pattern will result in the following defaults for the capabilities prompt:</p>
+    <code>
+      <pre>
+◉ Static web file serving
+◉ Swagger UI
+◉ Embedded metrics dashboard
+◉ Docker files</pre>
+    </code>
+    <h2>Capabilities prompt</h2>
+    <p>The application generator will ask which capabilities you want to select.</p>
+    <p>For Scaffold project type, the following capabilities are available:</p>
+  <code>
+    <pre>
+  Select capabilities: (Press {space} to select)
+❯ ◯ Static web file serving
+  ◯ Swagger UI
+  ◉ Embedded metrics dashboard
+  ◉ Docker files</pre>
+  </code>
+  <p>For CRUD project type, the following capabilities are available:</p>
+  <code>
+    <pre>
+  Select capabilities: (Press <space> to select)
+❯ ◉ Embedded metrics dashboard
+  ◉ Docker files</pre>
+  </code>
+  <p>The list allows for toggling of any combination of the available capabilities which will start with a default set selected.</p>
+  <blockquote class="info">
+    <p>CRUD project type always enables the OpenAPI / Swagger endpoint</p>
+  </blockquote>
+  <p>The capabilities selected by default when this prompt is shown depend on the project type:</p>
+  <ul>
+    <li>CRUD project type: all 3 available capabilities are selected by default</li>
+    <li>Scaffold project type: defaults depend on application pattern</li>
+  </ul>
+  <h3>Services prompt</h3>
+  <p>For scaffolded applications, the application generator will ask which services you want to select.</p>
+  <code>
+    <pre>
+  Generate boilerplate for services: (Press <space> to select)
+❯ ◯ Cloudant / CouchDB
+  ◯ Redis
+  ◯ MongoDB
+  ◯ PostgreSQL
+  ◯ Object Storage
+  ◯ AppID
+  ◯ Auto-scaling
+  ◯ Watson Conversation
+  ◯ Alert Notifications
+  ◯ Push Notifications</pre>
+  </code>
+  <h3>CRUD store prompt</h3>
+  <p>For CRUD applications, the application generator will ask how you want to store entities:</p>
+  <code>
+    <pre>
+  Select data store: (Use arrow keys)
+❯ Memory (for development purposes)
+  Cloudant / CouchDB</pre>
+  </code>
+  <p>Selecting Memory (for development purposes) will mean entities are stored in a simple memory-based database.</p>
+  <blockquote class="warning">
+    <p>The memory data store is volatile and any data added will be lost when the application is stopped. As such, it is only suitable for development purposes.</p>
+  </blockquote>
+  <p>Selecting Cloudant / CouchDB will add a local CouchDB service for entity storage.</p>
+  <h3>Service configuration prompt</h3>
+  <p>The application generator will ask you which of the services you selected need to be configured, for example:</p>
+  <code>
+    <pre>
+  Configure service credentials (leave unchecked for defaults): (Press <space> to select)
+❯ ◯ Cloudant / CouchDB
+  ◯ Redis
+  ◯ Object Storage</pre>
+  </code>
+  <p>Any services you do not select in this prompt will use default values.</p>
+    <p>For each service you select, a set of custom prompts will ask for the relevant connection details to be supplied.</p>
+
   </section>
   <section class="slack-help">
     <a href="http://slack.kitura.io/">

--- a/learn.html
+++ b/learn.html
@@ -52,6 +52,9 @@
               <li><a href="guides/kituracli/gettingstarted.html">> USING KITURA CREATE</a></li>
               <li><a href="guides/kituracli/deploying_cloud.html">> DEPLOYING TO THE CLOUD</a></li>
               <li><a href="guides/kituracli/docker.html">> USING WITH DOCKER</a></li>
+              <li><a href="guides/kituracli/model_definition.html">> MODEL DEFINITION JSON FILE</a></li>
+              <li><a href="guides/kituracli/layout_reference.html">> GENERATED PROJECT STRUCTURE</a></li>
+              <li><a href="guides/kituracli/ssg_rest.html">> EXPOSING SWIFT SERVER GENERATOR MODELS OVER REST</a></li>
           </ul>
       </div>
         <div class="guide-rectangle">


### PR DESCRIPTION
This PR adds links for the remaining Kitura CLI docs. 

The structure of these docs needs revisiting in the future but for now I think it's important these docs are at least visible on the website. 

I've added separate links for; 

- Model Definition JSON File
- Project Layout Reference (Called `Generated Project Structure` on the new website)
- Exposing Swift Server Generator Models Over Rest. 

I've also added the documentation around `Prompt Reference` when using Kitura Create to the `Using Kitura Create` doc. Then I added a contents section to this page to help navigate through this doc. 

The navigation links of the Contents section is based on what was added to `Deploying To The Cloud` by @KyeMaloy97 . This seems to not be linking to the sections correctly (the nav bar covers part of the section). I'll raise a separate issue to address this. 