### PR TITLE
Add warning to metrics doc

### DIFF
--- a/guides/building/metrics.html
+++ b/guides/building/metrics.html
@@ -66,6 +66,9 @@
       </tbody>
     </table>
     <h2>Adding SwiftMetrics monitoring to your application</h2>
+    <blockquote class="warning">
+      <p>If you created your Kitura application using the Kitura CLI or building a starter project using the kitura app then you will already have Swift Metrics included in your project.</p>
+    </blockquote>
     <p class="sentence">To add SwiftMetrics monitoring to your code</p>
     <pre><code class="language-swift">
 import SwiftMetrics

--- a/guides/building/metrics.html
+++ b/guides/building/metrics.html
@@ -66,8 +66,8 @@
       </tbody>
     </table>
     <h2>Adding SwiftMetrics monitoring to your application</h2>
-    <blockquote class="warning">
-      <p>If you created your Kitura application using the Kitura CLI or building a starter project using the kitura app then you will already have Swift Metrics included in your project.</p>
+    <blockquote class="tip">
+      <p>If you created your Kitura application using the Kitura CLI or by building a starter project using the kitura app then you will already have Swift Metrics included in your project.</p>
     </blockquote>
     <p class="sentence">To add SwiftMetrics monitoring to your code</p>
     <pre><code class="language-swift">


### PR DESCRIPTION
This PR adds a warning to the Swift Metrics documentation. The warning aims to inform users that they do not need to manually add Swift Metrics to their project if they've used the Kitura CLI tools or used the Kitura app to create a starter project. 

This is to resolve issue #150 