### PR TITLE
Add Swift-NIO to packages.html

### DIFF
--- a/packages.html
+++ b/packages.html
@@ -214,6 +214,9 @@
           <h3><a href="https://github.com/IBM-Swift/Kitura-net">Kitura-net</a></h3><a href="https://ibm-swift.github.io/Kitura-net/"><h5>API</h5></a>
           <h4>Logic for sending and receiving HTTP requests.</h4>
 
+          <h3><a href="https://github.com/IBM-Swift/Kitura-NIO">Kitura-NIO</a></h3><a href="https://developer.ibm.com/swift/2018/05/31/introducing-kitura-nio/"><h5>BETA</h5></a>
+          <h4>Logic for sending and receiving HTTP requests using Apple's SwiftNIO framework.</h4>
+
           <h3><a href="https://github.com/IBM-Swift/KituraContracts">Kitura Contracts</a></h3><a href="https://ibm-swift.github.io/KituraContracts/"><h5>API</h5></a>
           <h4>Type definitions shared by client and server.</h4>
 


### PR DESCRIPTION
 - Add Swift-NIO to the packages page underneath Kitura-net
 - Add a BETA tag (instead of API) which links though to the Kitura-NIO blog.

A preview of the proposed addition is attached here:
<img width="1440" alt="screen shot 2018-06-29 at 14 40 38" src="https://user-images.githubusercontent.com/20067264/42095571-e35cc2d8-7baa-11e8-964a-28be4ffb9e8c.png">