### PR TITLE
Prevent sideways scrolling on mobile devices

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -1,4 +1,4 @@
-html {
+html, body {
   overflow-x: hidden;
 }
 h1 {
@@ -50,6 +50,7 @@ h4 {
 }
 .slide-3 > h1 {
   font-size: 2em;
+  text-align: center;
 }
 .slide-3 > p {
   font-size: 1em;


### PR DESCRIPTION
Currently you can scroll sideways on mobile devices into empty content. 

This shouldn't be allowed as it hinders the users interactions with the website. 