### PR TITLE
Add a basic stylesheet for viewing the new learn page on mobile devices.

### DIFF
--- a/css/docs_mobile.css
+++ b/css/docs_mobile.css
@@ -34,6 +34,10 @@ pre {
   text-align: center;
 }
 
+.landing-heading > h1 {
+  font-size: 1.8rem;
+}
+
 .info {
   margin: 0 auto;
   margin-bottom: 2rem;

--- a/css/docs_mobile.css
+++ b/css/docs_mobile.css
@@ -1,0 +1,112 @@
+body {
+  padding: 1rem;
+}
+
+p, li {
+  font-size: 0.6rem;
+  text-align: center;
+}
+
+pre {
+  font-size: 0.6rem;
+  width: 80%;
+  margin: 0 auto;
+  margin-bottom: 1.5rem;
+}
+
+.heading-1 {
+  font-size: 1rem;
+  text-align: center;
+}
+
+.heading-2 {
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.heading-3 {
+  font-size: 0.8rem;
+  text-align: center;
+}
+
+.heading-4 {
+  font-size: 0.7rem;
+  text-align: center;
+}
+
+.info {
+  margin: 0 auto;
+  margin-bottom: 2rem;
+}
+
+.block-text {
+  line-height: 1rem;
+}
+
+.landing-grid-container {
+  display: block;
+}
+
+.landing-img, .circle-section {
+  display: none;
+}
+
+.landing-heading > h2 {
+  margin-top: 3rem;
+}
+
+.landing-heading > p {
+  width: 90%;
+  font-size: 0.6rem;
+}
+
+.tutorial {
+  width: 20rem;
+}
+
+.tutorial > p {
+  font-size: 0.6rem;
+}
+
+.tutorial > h3 {
+  font-size: 1rem;
+}
+
+.example-image {
+  width: 35%;
+}
+
+.macos-download-button {
+  display: none;
+}
+
+.server-grid-container {
+  display: block;
+}
+
+.stars {
+  display: none;
+}
+
+pre:hover:before {
+  content: '';
+  position: absolute;
+  opacity: 0;
+
+  transition: all 0.15s ease;
+  border-radius: 10px;
+}
+
+pre:hover:before {
+    /* needed - do not touch */
+    opacity: 1;
+
+    /* customizable */
+    right: 0;
+    top: 0;
+}
+
+.openapi-img {
+  width: 80vw;
+  margin: 0;
+}

--- a/css/main.css
+++ b/css/main.css
@@ -418,7 +418,22 @@ footer {
   font-size: 0.9em;
 }
 /* Learn styling */
-/* Learn Sytling */
+
+.burger-icon {
+  opacity: 0;
+  position: absolute;
+  top: 0.1rem;
+  left: 0.1rem;
+  padding: 1rem;
+}
+
+.burger-line {
+  height: 0.2rem;
+  width: 2rem;
+  background-color: #676767;
+  margin: 0.3rem 0;
+}
+
 .docs-sidebar {
 	height: 100vh;
   width: 20%;

--- a/css/main.css
+++ b/css/main.css
@@ -419,10 +419,18 @@ footer {
 }
 /* Learn styling */
 
+.sidebar-item {
+  font-size: 1.65rem;
+}
+
+.nested-sidebar-item {
+  font-size: 1.2rem;
+}
+
 .burger-icon {
   opacity: 0;
   position: absolute;
-  top: 0.1rem;
+  top: 1.7rem;
   left: 0.1rem;
   padding: 1rem;
 }

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -122,6 +122,16 @@ h4 {
   margin-left: 2rem;
 }
 
+.docs-title {
+  font-size: 1.8rem;
+}
+
+.nav-item {
+  font-size: 0.6rem;
+  margin-right: 1rem;
+  text-align: center;
+}
+
 /* old learn.html styling */
 .learn-grid-container {
   display: block;

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -1,5 +1,5 @@
 html, body {
-  overflow-x: hidden;
+   overflow-x: hidden;
 }
 h1 {
   font-size:2em;
@@ -74,7 +74,55 @@ h4 {
   width: 90%;
   margin: 10px 0
 }
-/* learn.html styling */
+
+.burger-icon {
+  opacity: 1;
+  z-index: 999;
+}
+
+.docs-sidebar {
+  width: 100%;
+  position: absolute;
+  overflow-y: scroll; /* has to be scroll, not auto */
+  -webkit-overflow-scrolling: touch;
+}
+
+#doc-container {
+  display: none;
+}
+
+#doc-window {
+  width: 100vw;
+  margin: 0 auto;
+  overflow-y: scroll; /* has to be scroll, not auto */
+  -webkit-overflow-scrolling: touch;
+}
+
+.apiref-button {
+  font-size: 1rem;
+}
+
+.burger-icon {
+  display: block;
+}
+
+.docs-grid-container {
+  display: block;
+}
+
+.sidebar-list {
+  text-align: center;
+}
+
+.nav-item {
+  margin: 0;
+}
+
+.apiref-button {
+  margin-left: 2rem;
+}
+
+/* old learn.html styling */
 .learn-grid-container {
   display: block;
 }

--- a/docs/authentication/authentication.html
+++ b/docs/authentication/authentication.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/authentication/typesafe-auth.html
+++ b/docs/authentication/typesafe-auth.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/databases/couchdb.html
+++ b/docs/databases/couchdb.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/databases/databases.html
+++ b/docs/databases/databases.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/databases/swift-kuery-orm.html
+++ b/docs/databases/swift-kuery-orm.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/databases/swift-kuery.html
+++ b/docs/databases/swift-kuery.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/deploying/cloud-foundry.html
+++ b/docs/deploying/cloud-foundry.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/deploying/docker.html
+++ b/docs/deploying/docker.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/deploying/kubernetes.html
+++ b/docs/deploying/kubernetes.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/deploying/monitoring.html
+++ b/docs/deploying/monitoring.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/getting-started/create-server-app.html
+++ b/docs/getting-started/create-server-app.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/getting-started/create-server-cli.html
+++ b/docs/getting-started/create-server-cli.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/getting-started/create-server-spm.html
+++ b/docs/getting-started/create-server-spm.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/getting-started/create-server.html
+++ b/docs/getting-started/create-server.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/getting-started/installation-linux.html
+++ b/docs/getting-started/installation-linux.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/main.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/getting-started/installation-mac.html
+++ b/docs/getting-started/installation-mac.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/main.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/getting-started/style-guide.html
+++ b/docs/getting-started/style-guide.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/getting-started/update-package.html
+++ b/docs/getting-started/update-package.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/landing.html
+++ b/docs/landing.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../css/reset.css">
     <link rel="stylesheet" href="../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/logging/helium-logger.html
+++ b/docs/logging/helium-logger.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/logging/logging.html
+++ b/docs/logging/logging.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/routing/codable-routing.html
+++ b/docs/routing/codable-routing.html
@@ -14,6 +14,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/routing/open-api.html
+++ b/docs/routing/open-api.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/routing/raw-routing.html
+++ b/docs/routing/raw-routing.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/routing/routing.html
+++ b/docs/routing/routing.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/sessions/kitura-session.html
+++ b/docs/sessions/kitura-session.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/sessions/sessions.html
+++ b/docs/sessions/sessions.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/templating/markdown.html
+++ b/docs/templating/markdown.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/templating/mustache.html
+++ b/docs/templating/mustache.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/templating/stencil.html
+++ b/docs/templating/stencil.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/docs/templating/templating.html
+++ b/docs/templating/templating.html
@@ -16,6 +16,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="../../css/reset.css">
     <link rel="stylesheet" href="../../css/docs.css">
+    <link rel="stylesheet" media="screen and (max-width: 900px)" href="../../css/docs_mobile.css">
     <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
   </head>
   <body>

--- a/learn.html
+++ b/learn.html
@@ -23,7 +23,7 @@
   </head>
 <body>
   <section class="docs-grid-container">
-    <aside class="docs-item-1 docs-sidebar">
+    <aside id="sidebar" class="docs-item-1 docs-sidebar">
       <h1 class="docs-title" onclick="loadPage('./docs/landing.html', '', 'https://ibm-swift.github.io/Kitura/')">KITURA <span class="docs-title-section">DOCS</span></h1>
       <div class="underline"></div>
       <nav class="sidebar-nav">
@@ -110,9 +110,14 @@
         </ul>
       </nav>
     </aside>
+    <div id="burgerIcon" class="burger-icon" onclick="showSidebar()">
+      <div class="burger-line"></div>
+      <div class="burger-line"></div>
+      <div class="burger-line"></div>
+    </div>
     <div class="docs-item-2 search-container">
       <!-- <input class="docs-search" type="text" name="searchInput" placeholder="Search documentation..."> -->
-      <div class="temp-beta">
+      <div id="beta" class="temp-beta">
         <h4>Currently in Beta - <a href="./old-learn.html">View old docs</a></h4>
       </div>
     </div>
@@ -121,7 +126,7 @@
       <a class="nav-item" target="_blank" href="http://slack.kitura.io/">Need help?</a>
       <a class="nav-item" target="_blank" href="https://github.com/IBM-Swift/kitura.io/issues">Found an issue?</a>
     </nav>
-    <div class="docs-item-4 docs-window">
+    <div id="doc-container" class="docs-item-4 docs-window">
       <iframe id="doc-window" width="100%" frameborder="0" scrolling="no" onload="resizeIframe()"></iframe>
     </div>
     <div id="top-page" class="top-page">
@@ -139,6 +144,21 @@
         target.style.display = "none";
       }
     }, false);
+
+    function showSidebar() {
+      var docSidebar = document.getElementById('sidebar');
+      var beta = document.getElementById('beta');
+      var docWindow = document.getElementById('doc-container');
+      if (docSidebar.style.display == 'block') {
+        beta.style.opacity = 1;
+        docSidebar.style.display = 'none';
+        docWindow.style.display = 'block';
+      } else {
+        docWindow.style.display = 'none';
+        beta.style.opacity = 0;
+        docSidebar.style.display = 'block';
+      }
+    }
   </script>
 </body>
 </html>

--- a/scripts/learn.js
+++ b/scripts/learn.js
@@ -10,7 +10,9 @@ if (localStorage.getItem("src") == undefined) {
 }
 
 function resizeIframe() {
-  document.getElementById('doc-window').style.height = document.getElementById('doc-window').contentWindow.document.body.scrollHeight + 'px';
+  if (document.documentElement.clientWidth > 900) {
+    document.getElementById('doc-window').style.height = document.getElementById('doc-window').contentWindow.document.body.scrollHeight + 'px';
+  }
 }
 
 
@@ -25,6 +27,14 @@ function addCollapsibleElements() {
       content.style.maxHeight = null;
     } else {
         for (var j = 0; j < items.length; j++) {
+          items[j].addEventListener("click", function() {
+            if (document.documentElement.clientWidth <= 900) {
+              var docSidebar = document.getElementById('sidebar');
+              docSidebar.style.display = 'none';
+              var docWindow = document.getElementById('doc-container');
+              docWindow.style.display = 'block';
+            }
+          })
           if (items[j].style.maxHeight !== null && items[j] !== content) {
             items[j].style.maxHeight = null;
           }


### PR DESCRIPTION
This PR enables usage of the new learn page on mobile devices. 

The main aim is to make the docs viewable/readable. In a later PR we can look at adding niceties such as animations for transitions. 

Some buttons have also been removed, such as the download the macOS app to ensure there's no accidental clicking on this button. 

We also need to look at improving the website view based on smaller screens, enabling a smooth responsiveness from mobile right the way up to desktop. 