### PR TITLE
Enable npm start to kick off the gulp command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ If you want to preview this website locally, follow these steps:
 
 1. Clone the `kitura.io` project onto your machine:
 `git clone https://github.com/IBM-Swift/kitura.io.git`
-2. Open the `index.html` which will open the home page. 
-`open index.html`
+2. Run the `npm install` command:
+`npm install`
+3. Then run:
+`npm start`
+
+This will open the website in your default browser using Gulp.
 
 ## Licence
 Apache Licence, Version 2.0
-

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+	  "start": "gulp"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR enables the usage of gulp for those without gulp-cli installed. 

Simply running `npm start` will kick off the gulp task runner. 