### PR TITLE
Fix broken links in Next Steps and Prerequisities

### DIFF
--- a/docs/getting-started/create-server-app.html
+++ b/docs/getting-started/create-server-app.html
@@ -21,9 +21,9 @@
   <body>
     <main>
       <h1 class="heading-1">Create a server with the Kitura macOS</h1>
-      <h2 class="heading-2" id="prereq">Prerequisites</h2>
+      <h2 class="heading-2">Prerequisites</h2>
       <ul class="plain-list">
-        <li><span class="blue-text">Kitura macOS app:</span> Follow our instructions for installing the Kitura macOS app.</li>
+        <li><a onclick="setActiveSidebarElementForParent('installation-mac')" href="../getting-started/installation-mac.html#install-macos-app">Kitura macOS app:</a> Follow our instructions for installing the Kitura macOS app.</li>
       </ul>
       <div class="underline"></div>
       <h2 class="heading-2"><span class="blue-text bold">Step 1:</span> Create project</h2>

--- a/docs/getting-started/create-server-cli.html
+++ b/docs/getting-started/create-server-cli.html
@@ -21,9 +21,9 @@
   <body>
     <main>
       <h1 class="heading-1">Create a server with the Kitura CLI</h1>
-      <h2 id="prereq">Prerequisites</h2>
+      <h2 class="heading-2">Prerequisites</h2>
       <ul class="plain-list">
-        <li><span class="blue-text">Kitura CLI:</span> Follow our instructions for installing the Kitura CLI.</li>
+        <li><a onclick="setActiveSidebarElementForParent('installation-linux')" href="../getting-started/installation-linux.html#install-cli">Kitura CLI:</a> Follow our instructions for installing the Kitura CLI.</li>
       </ul>
       <div class="underline"></div>
       <h2 class="heading-2"><span class="blue-text bold">Step 1:</span> Create a directory</h2>

--- a/docs/getting-started/create-server-spm.html
+++ b/docs/getting-started/create-server-spm.html
@@ -106,7 +106,7 @@
       <div class="underline"></div>
       <h2 class="heading-2">Next steps</h2>
       <p><span class="blue-text bold">Kitura Style Guide:</span> Learn the recommended structure for a Kitura project</p>
-      <p><span class="blue-text bold">Add logging:</span> Get useful feedback from your server about startup and errors</p>
+      <p><span class="blue-text"><a onclick="setActiveSidebarElementForParent('logging')" href="../logging/logging.html#">Add logging:</a></span> Get useful feedback from your server about startup and errors.</p>
     </main>
     <script type="text/javascript" src="../../scripts/docs.js"></script>
     <script type="text/javascript" src="../../scripts/prism.js"></script>

--- a/docs/getting-started/installation-linux.html
+++ b/docs/getting-started/installation-linux.html
@@ -40,7 +40,7 @@
       <h2 class="heading-2">Next steps</h2>
       <p><span class="blue-text"><a onclick="setActiveSidebarElementForParent('create-server')" href="create-server-spm.html#">Create a Kitura server:</a></span> Make use of SPM to create a server.</p>
       <div class="underline"></div>
-      <h2 class="heading-2"><span class="blue-text bold">Optional:</span> Install Kitura CLI</h2>
+      <h2 class="heading-2" id="install-cli"><span class="blue-text bold">Optional:</span> Install Kitura CLI</h2>
       <h3 class="heading-3">Install via npm</h3>
       <p>For this installation method you need to have npm installed.</p>
       <p>If you do not have npm installed you can follow the <a target="_blank" href="https://www.npmjs.com/get-npm">npm installation steps</a>.</p>

--- a/docs/getting-started/installation-mac.html
+++ b/docs/getting-started/installation-mac.html
@@ -67,7 +67,7 @@
       <h2 class="heading-2">Next steps</h2>
       <p><span class="blue-text"><a onclick="setActiveSidebarElementForParent('create-server')" href="create-server-cli.html#">Create a Kitura server:</a></span> Make use of the Kitura CLI to create a server.</p>
       <div class="underline"></div>
-      <h2 class="heading-2"><span class="blue-text bold">Optional:</span> Install Kitura macOS app</h2>
+      <h2 class="heading-2" id="install-macos-app"><span class="blue-text bold">Optional:</span> Install Kitura macOS app</h2>
       <p class="block-text">The Kitura macOS app provides a user interface (UI) cover for the Kitura CLI. This option is designed for those who wish to avoid using the command line to create a simple cloud ready Kitura project.</p>
       <h3 class="heading-3"><span class="blue-text bold">Step 1:</span> Download the macOS app</h3>
       <p>To download the macOS app click the button below:</p>

--- a/docs/getting-started/update-package.html
+++ b/docs/getting-started/update-package.html
@@ -66,8 +66,8 @@
       <p>We have now added a new package to our project and are ready to start using this in our app.</p>
       <div class="underline"></div>
       <h2 class="heading-2">Next steps</h2>
-      <p><span class="blue-text bold">Add logging:</span> Get useful feedback from your server about startup and errors</p>
-      <p><span class="blue-text bold">Add routing:</span> Add REST APIs, such as HTTP GET, to your server</p>
+      <p><span class="blue-text"><a onclick="setActiveSidebarElementForParent('logging')" href="../logging/logging.html#">Add logging:</a></span> Get useful feedback from your server about startup and errors.</p>
+      <p><span class="blue-text"><a onclick="setActiveSidebarElementForParent('routing')" href="../routing/routing.html#">Add routing:</a></span> Add REST APIs, such as HTTP GET, to your server.</p>
     </main>
     <!-- <script defer type="text/javascript" src="../../scripts/prism.js"></script> -->
     <script type="text/javascript" src="../../scripts/update-package.js"></script>

--- a/docs/logging/logging.html
+++ b/docs/logging/logging.html
@@ -25,7 +25,7 @@
       <!-- <p class="block-text">Imagine if your server is running, you make a request to the server but nothing happens. You do not get what you expected from the server. Now imagine if you were not given any information about why this issue is happening? The term `a needle in a haystack` may seem appropriate here. This illustrate how important logging can be when something does go wrong. In an ideal world everything would work perfectly but as we all know things can sometimes go wrong. For that reason Kitura makes extensive use of logging throughout the application. This way you can be sure to know what the server is doing at any given time, so if an error occurs it can help pinpoint the issue as well as providing some useful information. You can then use this information to either attempt to fix the issue or raise a question within our <a target="_blank" href="http://slack.kitura.io/">Slack channel.</a></p>
       <p class="block-text">It is also useful to use Logging within your own server-side code. Doing so will help you debug your own code and help narrow down where potential issues are arising.</p> -->
       <h2 class="heading-2">Next steps</h2>
-      <p><span class="blue-text bold">Add logging:</span> Get useful feedback from your server about startup and errors.</p>
+      <p><span class="blue-text"><a onclick="setActiveSidebarElementForParent('logging')" href="../logging/helium-logger.html#">Add logging:</a></span> Get useful feedback from your server about startup and errors.</p>
     </main>
   </body>
 </html>

--- a/docs/routing/routing.html
+++ b/docs/routing/routing.html
@@ -136,8 +136,8 @@
       <p class="block-text">Codable Routing isn’t suitable for every use case and scenario, so Raw Routing is still available where you need the power and flexibility.</p>
       <div class="underline"></div>
       <h2 class="heading-2">Next steps</h2>
-      <p><a href="codable-routing.html"><span class="blue-text bold">Add Codable Routing:</span></a> Get useful feedback from your server about startup and errors</p>
-      <p><a href="raw-routing.html"><span class="blue-text bold">Add Raw Routing:</span></a> Add REST APIs, such as HTTP GET, to your server</p>
+      <p><span class="blue-text"><a onclick="setActiveSidebarElementForParent('routing')" href="../routing/codable-routing.html#">Add Codable Routing:</a></span>  Add REST APIs, such as HTTP GET, to your server with Codable routing.</p>
+      <p><span class="blue-text"><a onclick="setActiveSidebarElementForParent('routing')" href="../routing/raw-routing.html#">Add Raw Routing:</a></span>  Add REST APIs, such as HTTP GET, to your server with Raw routing.</p>
     </main>
     <script type="text/javascript" src="../../scripts/prism.js"></script>
   </body>


### PR DESCRIPTION
@ddunn2 The `id` links don't seem to work quite as I'd expected, please can you take a look?

Other points to discuss -
- I've linked out from Kitura CLI in the prerequisites section to the install instructions for installing Kitura CLI on Linux, but it is possible the user might be installing Kitura CLI on macOS...?