### PR TITLE
Migrate SSL guide from old docs

### DIFF
--- a/docs/deploying/ssl.html
+++ b/docs/deploying/ssl.html
@@ -27,31 +27,36 @@
     </ul>
     <p class="block-text">TLS evolved out of Netscape’s Secure Sockets Layer (SSL) protocol in order to fix most of its security flaws.
          The industry still uses the terms somewhat interchangeably for historical reasons.
-          Any web site that you visit starting with https:// rather than http:// is using TLS/SSL for communication between your browser and their server.</p>
+         Any web site that you visit starting with https:// rather than http:// is using TLS/SSL for communication between your browser and their server.</p>
+      <p class="block-text">This guide will demonstrate how to enable the TLS protocol directly on your Kitura server. Another way to enable TLS is via an SSL/TLS proxy.
+           In this case an intermediary application between your server and clients performs the encryption and decryption.
+            Some cloud providers offer this service by default so check if that is a more appropriate solution before proceeding with this guide.</p>
       <div class="underline"></div>
       <h2 class="heading-2" id="prereq">Prerequisites</h2>
       <ul class="plain-list">
           <li><a onclick="setActiveSidebarElementForParent('create-server')" href="../getting-started/create-server.html#">Kitura Server:</a> Learn how to create one in our Getting Started guide.</li>
           <li><a onclick="setActiveSidebarElementForParent('style-guide')" href="../getting-started/style-guide.html#">Kitura Style Guide:</a> Follow our guide to see how a production ready server should be structured.</li>
           <li><a onclick="localStorage.setItem('package', 'FileKit'); setActiveSidebarElementForParent('filekit')" href="../getting-started/update-package.html#">Update Dependencies:</a> FileKit needs adding to the `Package.swift` file.</li>
-          <li>Install OpenSSL: In this guide, we will use OpenSSL to generate our self-signed certificate.</li>
       </ul>
+      <h3 class="heading-3">Install OpenSSL</h3>
+      <p>In this guide, we will use OpenSSL to generate our self-signed certificate.</p>
       <p>OpenSSL is included by default on Linux. On MacOS we can install it using Homebrew:</p>
       <pre><code>brew install openssl</code></pre>
-      <p>We then link it so we can use the OpenSSL CLI:</p>
-      <pre><code>ln -s /usr/local/opt/openssl/include/openssl /usr/local/include</code></pre>
       <div class="underline"></div>
-      <h2 class="heading-2"><span class="blue-text">Step 1:</span> Create our certificate and key pair.</h2>
+      <h2 class="heading-2"><span class="blue-text">Step 1:</span> Create our certificate and key pair</h2>
       <p class="block-text">To enable TLS, a server needs a certificate and a corresponding secret key.
            Certificates are files that bind together information about the identity of the owner of a site and the public half of an asymmetric key pair (usually RSA).
            Certificates are usually digitally signed by a certificate authority (CA) who verifies that the identity information in the certificate is correct.
            This creates a chain of certificates between the site owner certificate and a CA certificate and transitive trust.
             Assuming that we trust the CA, we can trust the validity of the server certificate.</p>
        <div class="info">
-          <p class="block-text">If you want to create a CA-signed certificate chain, a useful tool to use is <a href="https://letsencrypt.org/" target="_blank">Let’s Encrypt</a>,
-           a free, automated and open CA, provided by the Internet Security Research Group (ISRG).</p>
+          <p class="block-text">
+              If you want to create a CA-signed certificate chain,
+              <a href="https://letsencrypt.org/" target="_blank">Let’s Encrypt</a> is a Certificate Authority (CA),
+              provided by the non-profit Internet Security Research Group (ISRG) that makes it easy to generate and install free TLS/SSL certificates.
+           </p>
        </div>
-      <p>For this guide we will use OpenSSL to generate a self-signed certificate.</p>
+      <p>In this guide, we will use OpenSSL to generate a self-signed certificate.</p>
       <p>Create a Credentials folder in the root of your project:</p>
       <pre><code>mkdir Credentials && cd Credentials</code></pre>
       <p>Inside this folder we create a 2048 bit RSA private key using OpenSSL:</p>
@@ -59,20 +64,21 @@
       <p>We use this private key to create a certificate:</p>
       <pre><code>openssl req -new -sha256 -key key.pem -out csr.csr</code></pre>
       <p class="block-text">At this stage you provide additional information that will be stored in the certificate.</p>
-      <p class="block-text">These choices are optional except for Common Name which must be the servers hostname. In our case this is "localhost".</p>
+      <p class="block-text">These choices are optional, except for Common Name, which must be the server's hostname. In our case, this is "localhost".</p>
       <p>Next we use OpenSSL to convert the certificate to PEM format:</p>
       <pre><code>openssl req -x509 -sha256 -days 365 -key key.pem -in csr.csr -out cert.pem</code></pre>
       <p>Finally we encrypt the key and certificate together using a password. For simplicity we will use "password".</p>
       <pre><code>openssl pkcs12 -export -out cert.pfx -inkey key.pem -in cert.pem</code></pre>
 <div class="underline"></div>
       <h2 class="heading-2"><span class="blue-text">Step 2:</span> Setting up your SSL configuration</h2>
-      <p>Open your `Sources` > `Application` > `Application.swift`</p>
+      <p>Now we have created our certificate, we are going to set up our SSL configuration so that it can direct Kitura to the required files.</p>
+      <p>Open your `Sources` > `Application` > `Application.swift` file.</p>
       <p>We are going to use <a href="https://github.com/IBM-Swift/FileKit" target="_blank">FileKit</a> to access our certificate file.</p>
       <p>This means we need to add FileKit to our import statements:</p>
       <pre><code class="language-swift">import FileKit</code></pre>
-      <p>Now we initialize an `SSLConfig` struct. On macOS we use Apple Secure Transport under the covers which requires the path to our `cert.pfx` file and
-           the password we used to encrypt the file. On linux we use OpenSSL under the covers which requires the paths to the certificate and private key PEM files.</p>
-      <p>We use `#if` to check the system version and provide the appropriate requirements to our config. </p>
+      <p>Now we initialize an `SSLConfig` struct. On macOS we use Apple Secure Transport under the covers, which requires the path to our `cert.pfx` file and
+           the password we used to encrypt the file. On Linux we use OpenSSL under the covers, which requires the paths to the certificate and private key PEM files.</p>
+      <p>We use `#if` to check which operating system we're running on and provide the appropriate files to our configuration. </p>
       <p>Inside the `App` class, add the following code:<p>
       <pre><code class="language-swift">#if os(Linux)
 let mySSLConfig =  SSLConfig(withCACertificateDirectory: nil,
@@ -88,21 +94,20 @@ let mySSLConfig =  SSLConfig(withChainFilePath: FileKit.projectFolder + "/Creden
 #endif</code></pre>
       <div class="underline"></div>
       <h2 class="heading-2"><span class="blue-text">Step 3:</span> Configure our Kitura server to use SSL</h2>
-      <p>Now we have our SSL configuration, we need to pass it to Kitura when we register server.
-      We do this as part of the `addHTTPServer` function using the `withSSL` parameter.</p>
-      <p>Inside the run function, Replace:</p>
+      <p>Now we have our SSL configuration, we need to pass it to Kitura.
+      We do this as part of the `addHTTPServer` function, using the `withSSL` parameter.</p>
+      <p>Inside the run function, replace:</p>
       <pre><code class="language-swift">Kitura.addHTTPServer(onPort: 8080, with: router)</code></pre>
       <p>With the following code:</p>
       <pre><code class="language-swift">Kitura.addHTTPServer(onPort: 8080, with: router, withSSL: sslConfig)</code></pre>
-      <p class="block-text">Thats it! Your server will now use TLS to secure exchange data between server and client.</p>
-      <p>To test this start your server and open your browser at the kitura landing page:</p>
+      <p>To test this, start your server and open your browser at the kitura landing page:</p>
       <p><a href="https://localhost:8080" target="_blank">https://localhost:8080</a></p>
       <div class="info">
       <p class="block-text">At this point your browser might give you a warning that the SSL certificate it is validating is self-signed.
            Since you are accessing your own server this isn’t a problem at all, and you can simply tell your web-browser to accept the self-signed SSL certificate and continue.
             In general though, your browser should only trust server certificates which are issued by a valid CA.</p>
         </div>
-      <p class="block-text">Notice the https in your URL! You are running Kitura with TLS!
+      <p class="block-text">Notice the https in your URL. You are running Kitura using SSL/TLS!
            This means that the data your application transmits is secure and the server your users are connecting to is authenticated.
 <div class="underline"></div>
       <h2 class="heading-2">Next steps</h2>

--- a/docs/deploying/ssl.html
+++ b/docs/deploying/ssl.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-73924704-2"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-73924704-2', { 'anonymize_ip': true });
+    </script>
+    <title>Learn - Getting Started</title>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="../../css/reset.css">
+    <link rel="stylesheet" href="../../css/dist/docs.css">
+    <link href=“https://fonts.googleapis.com/css?family=IBM+Plex+Sans” rel=“stylesheet”>
+  </head>
+  <body>
+    <main>
+      <h1 class="heading-1">Enabling SSL/TLS</h1>
+      <p class="block-text">Transport Layer Security (TLS) is a protocol for encrypting data that is sent over the internet. It provides three important features:</p>
+      <ul>
+        <li>Data Privacy: The data that is exchanged between a server and client is not visible to anyone else.</li>
+        <li>Data Integrity: The data that is exchanged between a server and client cannot be modified by anyone else.</li>
+        <li>Server Authenticity: The server can prove its identity to the client and so prove the origin of sent data.</li>
+    </ul>
+    <p class="block-text">TLS evolved out of Netscape’s Secure Sockets Layer (SSL) protocol in order to fix most of its security flaws.
+         The industry still uses the terms somewhat interchangeably for historical reasons.
+          Any web site that you visit starting with https:// rather than http:// is using TLS/SSL for communication between your browser and their server.</p>
+      <div class="underline"></div>
+      <h2 class="heading-2" id="prereq">Prerequisites</h2>
+      <ul class="plain-list">
+          <li><a onclick="setActiveSidebarElementForParent('create-server')" href="../getting-started/create-server.html#">Kitura Server:</a> Learn how to create one in our Getting Started guide.</li>
+          <li><a onclick="setActiveSidebarElementForParent('style-guide')" href="../getting-started/style-guide.html#">Kitura Style Guide:</a> Follow our guide to see how a production ready server should be structured.</li>
+          <li><a onclick="localStorage.setItem('package', 'FileKit'); setActiveSidebarElementForParent('filekit')" href="../getting-started/update-package.html#">Update Dependencies:</a> FileKit needs adding to the `Package.swift` file.</li>
+          <li>Install OpenSSL: In this guide, we will use OpenSSL to generate our self-signed certificate.</li>
+      </ul>
+      <p>OpenSSL is included by default on Linux. On MacOS we can install it using Homebrew:</p>
+      <pre><code>brew install openssl</code></pre>
+      <p>We then link it so we can use the OpenSSL CLI:</p>
+      <pre><code>ln -s /usr/local/opt/openssl/include/openssl /usr/local/include</code></pre>
+      <div class="underline"></div>
+      <h2 class="heading-2"><span class="blue-text">Step 1:</span> Create our certificate and key pair.</h2>
+      <p class="block-text">To enable TLS, a server needs a certificate and a corresponding secret key.
+           Certificates are files that bind together information about the identity of the owner of a site and the public half of an asymmetric key pair (usually RSA).
+           Certificates are usually digitally signed by a certificate authority (CA) who verifies that the identity information in the certificate is correct.
+           This creates a chain of certificates between the site owner certificate and a CA certificate and transitive trust.
+            Assuming that we trust the CA, we can trust the validity of the server certificate.</p>
+       <div class="info">
+          <p class="block-text">If you want to create a CA-signed certificate chain, a useful tool to use is Let’s Encrypt,
+           a free, automated and open CA, provided by the Internet Security Research Group (ISRG).</p>
+       </div>
+      <p>For this guide we will use OpenSSL to generate a self-signed certificate.</p>
+      <p>Create a Credentials folder in the root of your project:</p>
+      <pre><code>mkdir Credentials && cd Credentials</code></pre>
+      <p>Inside this folder we create a 2048 bit RSA private key using OpenSSL:</p>
+      <pre><code>openssl genrsa -out key.pem 2048</code></pre>
+      <p>We use this private key to create a certificate:</p>
+      <pre><code>openssl req -new -sha256 -key key.pem -out csr.csr</code></pre>
+      <p class="block-text">At this stage you provide additional information that will be stored in the certificate.</p>
+      <p class="block-text">These choices are optional except for Common Name which must be the servers hostname. In our case this is "localhost".</p>
+      <p>Next we use OpenSSL to convert the certificate to PEM format:</p>
+      <pre><code>openssl req -x509 -sha256 -days 365 -key key.pem -in csr.csr -out cert.pem</code></pre>
+      <p>Finally we encrypt the key and certificate together using a password. For simplicity we will use "password".</p>
+      <pre><code>openssl pkcs12 -export -out cert.pfx -inkey key.pem -in cert.pem</code></pre>
+      <p>The `cert.pfx` file is the one we need to enable SSL on our server.
+         The other files can be deleted so that you don't store any credentials in plaintext.</p>
+<div class="underline"></div>
+      <h2 class="heading-2"><span class="blue-text">Step 2:</span> Setting up your SSL configuration</h2>
+      <p>Open your `Sources` > `Application` > `Application.swift`</p>
+      <p>We are going to use <a href="https://github.com/IBM-Swift/FileKit" target="_blank">FileKit</a> to access our certificate file.</p>
+      <p>This means we need to add FileKit to our import statements:</p>
+      <pre><code class="language-swift">import FileKit</code></pre>
+      <p>Now we initialize an `SSLConfig` struct by providing the path to our `cert.pfx` file,
+           the password we used to encrypt the file and setting `usingSelfSignedCerts` to be true.</p>
+      <p>Inside the `App` class, add the following code:<p>
+      <pre><code class="language-swift">let sslConfig = SSLConfig(withChainFilePath: FileKit.projectFolder + "/Credentials/cert.pfx",
+                            withPassword: "password",
+                            usingSelfSignedCerts: true)</code></pre>
+      <div class="info">
+        <p class="block-text">In a real project ensure your password is stored as an environment variable.</p>
+      </div>
+      <div class="underline"></div>
+      <h2 class="heading-2"><span class="blue-text">Step 3:</span> Configure our Kitura server to use SSL</h2>
+      <p>Now we have our SSL configuration, we need to pass it to Kitura when we register server.
+      We do this as part of the `addHTTPServer` function using the `withSSL` parameter.</p>
+      <p>Inside the run function, Replace:</p>
+      <pre><code class="language-swift">Kitura.addHTTPServer(onPort: 8080, with: router)</code></pre>
+      <p>With the following code:</p>
+      <pre><code class="language-swift">Kitura.addHTTPServer(onPort: 8080, with: router, withSSL: sslConfig)</code></pre>
+      <p class="block-text">Thats it! Your server will now use TLS to secure exchange data between server and client.</p>
+      <p>To test this start your server and open your browser at:</p>
+      <p><a href="https://localhost:8080" target="_blank">https://localhost:8080</a></p>
+      <div class="info">
+      <p class="block-text">At this point your browser might give you a warning that the SSL certificate it is validating is self-signed.
+           Since you are accessing your own server this isn’t a problem at all, and you can simply tell your web-browser to accept the self-signed SSL certificate and continue.
+            In general though, your browser should only trust server certificates which are issued by a valid CA.</p>
+        </div>
+      <p class="block-text">Notice the https in your URL! You are running Kitura with TLS!
+           This means that the data your application transmits is secure and the server your users are connecting to is authenticated.
+<div class="underline"></div>
+      <h2 class="heading-2">Next steps</h2>
+      <p>Coming Soon!</p>
+    </main>
+    <script type="text/javascript" src="../../scripts/docs.js"></script>
+    <script type="text/javascript" src="../../scripts/prism.js"></script>
+  </body>
+</html>

--- a/docs/deploying/ssl.html
+++ b/docs/deploying/ssl.html
@@ -48,7 +48,7 @@
            This creates a chain of certificates between the site owner certificate and a CA certificate and transitive trust.
             Assuming that we trust the CA, we can trust the validity of the server certificate.</p>
        <div class="info">
-          <p class="block-text">If you want to create a CA-signed certificate chain, a useful tool to use is Let’s Encrypt,
+          <p class="block-text">If you want to create a CA-signed certificate chain, a useful tool to use is <a href="https://letsencrypt.org/" target="_blank">Let’s Encrypt</a>,
            a free, automated and open CA, provided by the Internet Security Research Group (ISRG).</p>
        </div>
       <p>For this guide we will use OpenSSL to generate a self-signed certificate.</p>
@@ -64,23 +64,28 @@
       <pre><code>openssl req -x509 -sha256 -days 365 -key key.pem -in csr.csr -out cert.pem</code></pre>
       <p>Finally we encrypt the key and certificate together using a password. For simplicity we will use "password".</p>
       <pre><code>openssl pkcs12 -export -out cert.pfx -inkey key.pem -in cert.pem</code></pre>
-      <p>The `cert.pfx` file is the one we need to enable SSL on our server.
-         The other files can be deleted so that you don't store any credentials in plaintext.</p>
 <div class="underline"></div>
       <h2 class="heading-2"><span class="blue-text">Step 2:</span> Setting up your SSL configuration</h2>
       <p>Open your `Sources` > `Application` > `Application.swift`</p>
       <p>We are going to use <a href="https://github.com/IBM-Swift/FileKit" target="_blank">FileKit</a> to access our certificate file.</p>
       <p>This means we need to add FileKit to our import statements:</p>
       <pre><code class="language-swift">import FileKit</code></pre>
-      <p>Now we initialize an `SSLConfig` struct by providing the path to our `cert.pfx` file,
-           the password we used to encrypt the file and setting `usingSelfSignedCerts` to be true.</p>
+      <p>Now we initialize an `SSLConfig` struct. On macOS we use Apple Secure Transport under the covers which requires the path to our `cert.pfx` file and
+           the password we used to encrypt the file. On linux we use OpenSSL under the covers which requires the paths to the certificate and private key PEM files.</p>
+      <p>We use `#if` to check the system version and provide the appropriate requirements to our config. </p>
       <p>Inside the `App` class, add the following code:<p>
-      <pre><code class="language-swift">let sslConfig = SSLConfig(withChainFilePath: FileKit.projectFolder + "/Credentials/cert.pfx",
-                            withPassword: "password",
-                            usingSelfSignedCerts: true)</code></pre>
-      <div class="info">
-        <p class="block-text">In a real project ensure your password is stored as an environment variable.</p>
-      </div>
+      <pre><code class="language-swift">#if os(Linux)
+let mySSLConfig =  SSLConfig(withCACertificateDirectory: nil,
+                             usingCertificateFile: FileKit.projectFolder + "/Credentials/cert.pem",
+                             withKeyFile: FileKit.projectFolder + "/Credentials/key.pem",
+                             usingSelfSignedCerts: true)
+#else // on macOS
+
+let mySSLConfig =  SSLConfig(withChainFilePath: FileKit.projectFolder + "/Credentials/cert.pfx",
+                             withPassword: "password",
+                             usingSelfSignedCerts: true)
+
+#endif</code></pre>
       <div class="underline"></div>
       <h2 class="heading-2"><span class="blue-text">Step 3:</span> Configure our Kitura server to use SSL</h2>
       <p>Now we have our SSL configuration, we need to pass it to Kitura when we register server.
@@ -90,7 +95,7 @@
       <p>With the following code:</p>
       <pre><code class="language-swift">Kitura.addHTTPServer(onPort: 8080, with: router, withSSL: sslConfig)</code></pre>
       <p class="block-text">Thats it! Your server will now use TLS to secure exchange data between server and client.</p>
-      <p>To test this start your server and open your browser at:</p>
+      <p>To test this start your server and open your browser at the kitura landing page:</p>
       <p><a href="https://localhost:8080" target="_blank">https://localhost:8080</a></p>
       <div class="info">
       <p class="block-text">At this point your browser might give you a warning that the SSL certificate it is validating is self-signed.

--- a/docs/deploying/ssl.html
+++ b/docs/deploying/ssl.html
@@ -28,9 +28,11 @@
     <p class="block-text">TLS evolved out of Netscape’s Secure Sockets Layer (SSL) protocol in order to fix most of its security flaws.
          The industry still uses the terms somewhat interchangeably for historical reasons.
          Any web site that you visit starting with https:// rather than http:// is using TLS/SSL for communication between your browser and their server.</p>
+    <div class="info">
       <p class="block-text">This guide will demonstrate how to enable the TLS protocol directly on your Kitura server. Another way to enable TLS is via an SSL/TLS proxy.
            In this case an intermediary application between your server and clients performs the encryption and decryption.
-            Some cloud providers offer this service by default so check if that is a more appropriate solution before proceeding with this guide.</p>
+           Some cloud providers offer this service by default, which may be a more appropriate solution.</p>
+      </div>
       <div class="underline"></div>
       <h2 class="heading-2" id="prereq">Prerequisites</h2>
       <ul class="plain-list">
@@ -81,13 +83,13 @@
       <p>We use `#if` to check which operating system we're running on and provide the appropriate files to our configuration. </p>
       <p>Inside the `App` class, add the following code:<p>
       <pre><code class="language-swift">#if os(Linux)
-let mySSLConfig =  SSLConfig(withCACertificateDirectory: nil,
+let sslConfig =  SSLConfig(withCACertificateDirectory: nil,
                              usingCertificateFile: FileKit.projectFolder + "/Credentials/cert.pem",
                              withKeyFile: FileKit.projectFolder + "/Credentials/key.pem",
                              usingSelfSignedCerts: true)
 #else // on macOS
 
-let mySSLConfig =  SSLConfig(withChainFilePath: FileKit.projectFolder + "/Credentials/cert.pfx",
+let sslConfig =  SSLConfig(withChainFilePath: FileKit.projectFolder + "/Credentials/cert.pfx",
                              withPassword: "password",
                              usingSelfSignedCerts: true)
 
@@ -103,9 +105,9 @@ let mySSLConfig =  SSLConfig(withChainFilePath: FileKit.projectFolder + "/Creden
       <p>To test this, start your server and open your browser at the kitura landing page:</p>
       <p><a href="https://localhost:8080" target="_blank">https://localhost:8080</a></p>
       <div class="info">
-      <p class="block-text">At this point your browser might give you a warning that the SSL certificate it is validating is self-signed.
-           Since you are accessing your own server this isn’t a problem at all, and you can simply tell your web-browser to accept the self-signed SSL certificate and continue.
-            In general though, your browser should only trust server certificates which are issued by a valid CA.</p>
+      <p class="block-text">At this point your browser might stop you with a warning that the SSL certificate it is validating is self-signed.
+           Since you are accessing your own server this isn’t a problem at all. In the advanced settings, you can tell your web-browser to accept the self-signed SSL certificate and continue.
+           In general though, your browser should only trust server certificates which are issued by a valid CA.</p>
         </div>
       <p class="block-text">Notice the https in your URL. You are running Kitura using SSL/TLS!
            This means that the data your application transmits is secure and the server your users are connecting to is authenticated.

--- a/docs/deploying/ssl.html
+++ b/docs/deploying/ssl.html
@@ -102,7 +102,7 @@ let sslConfig =  SSLConfig(withChainFilePath: FileKit.projectFolder + "/Credenti
       <pre><code class="language-swift">Kitura.addHTTPServer(onPort: 8080, with: router)</code></pre>
       <p>With the following code:</p>
       <pre><code class="language-swift">Kitura.addHTTPServer(onPort: 8080, with: router, withSSL: sslConfig)</code></pre>
-      <p>To test this, start your server and open your browser at the kitura landing page:</p>
+      <p>To test this, start your server and open your browser at the Kitura landing page:</p>
       <p><a href="https://localhost:8080" target="_blank">https://localhost:8080</a></p>
       <div class="info">
       <p class="block-text">At this point your browser might stop you with a warning that the SSL certificate it is validating is self-signed.

--- a/learn.html
+++ b/learn.html
@@ -100,6 +100,7 @@
         <li class="sidebar-item collapsible">Deploying</li>
         <ul class="nested-sidebar-list content">
           <li id="monitoring" class="nested-sidebar-item selectable" onclick="loadPage('./docs/deploying/monitoring.html#', 'monitoring', 'https://ibm-swift.github.io/Kitura/')">Monitoring</li>
+          <li id="ssl" class="nested-sidebar-item selectable" onclick="loadPage('./docs/deploying/ssl.html#', 'ssl', 'https://ibm-swift.github.io/Kitura/')">Enabling SSL/TLS</li>
           <li id="docker" class="nested-sidebar-item selectable" onclick="loadPage('./docs/deploying/docker.html#', 'docker', 'https://ibm-swift.github.io/Kitura/')">Docker</li>
           <li id="kubernetes" class="nested-sidebar-item selectable" onclick="loadPage('./docs/deploying/kubernetes.html#', 'kubernetes', 'https://ibm-swift.github.io/Kitura/')">Kubernetes</li>
           <li id="cloud-foundry" class="nested-sidebar-item selectable" onclick="loadPage('./docs/deploying/cloud-foundry.html#', 'cloud-foundry', 'https://ibm-swift.github.io/Kitura/')">Cloud Foundry</li>


### PR DESCRIPTION
This pull request migrates the old guide on [Enabling SSL](https://www.kitura.io/guides/building/ssl.html) to the new guide. 