### PR TITLE
Add link to static file server guide

### DIFF
--- a/docs/sessions/kitura-session.html
+++ b/docs/sessions/kitura-session.html
@@ -69,6 +69,7 @@
         <li class="sidebar-item collapsible">Web Application</li>
         <ul class="nested-sidebar-list content">
           <li class="nested-sidebar-item"><a href="../templating/templating.html">What is templating?</a></li>
+	  <li class="nested-sidebar-item"><a href="../templating/static-file-server.html">Static File Server</a></li>
           <li class="nested-sidebar-item"><a href="../templating/stencil.html">Stencil</a></li>
           <li class="nested-sidebar-item"><a href="../templating/markdown.html">Markdown</a></li>
         </ul>


### PR DESCRIPTION
Link to static file server was missing from toolbar of new sessions guide.