### PR TITLE
Add default height to sidebar page

### DIFF
--- a/docs/authentication/authentication.html
+++ b/docs/authentication/authentication.html
@@ -60,7 +60,7 @@
           <li class="nested-sidebar-item"><a href="../sessions/type-safe-session.html">Codable Routing Session</a></li>
         </ul>
         <li class="sidebar-item collapsible">Authentication</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item active"><a href="../authentication/authentication.html">What is Authentication?</a></li>
           <li class="nested-sidebar-item"><a href="../authentication/typesafe-auth.html">Type-Safe Credentials</a></li>
           <li class="nested-sidebar-item"><a href="../authentication/jwt-auth.html">JSON Web Tokens</a></li>

--- a/docs/authentication/authentication.html
+++ b/docs/authentication/authentication.html
@@ -60,7 +60,7 @@
           <li class="nested-sidebar-item"><a href="../sessions/type-safe-session.html">Codable Routing Session</a></li>
         </ul>
         <li class="sidebar-item collapsible">Authentication</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item active"><a href="../authentication/authentication.html">What is Authentication?</a></li>
           <li class="nested-sidebar-item"><a href="../authentication/typesafe-auth.html">Type-Safe Credentials</a></li>
           <li class="nested-sidebar-item"><a href="../authentication/jwt-auth.html">JSON Web Tokens</a></li>

--- a/docs/authentication/fb-google-oauth2.html
+++ b/docs/authentication/fb-google-oauth2.html
@@ -60,7 +60,7 @@
           <li class="nested-sidebar-item"><a href="../sessions/type-safe-session.html">Codable Routing Session</a></li>
         </ul>
         <li class="sidebar-item collapsible">Authentication</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../authentication/authentication.html">What is Authentication?</a></li>
           <li class="nested-sidebar-item"><a href="../authentication/typesafe-auth.html">Type-Safe Credentials</a></li>
           <li class="nested-sidebar-item"><a href="../authentication/jwt-auth.html">JSON Web Tokens</a></li>

--- a/docs/authentication/fb-google-oauth2.html
+++ b/docs/authentication/fb-google-oauth2.html
@@ -60,7 +60,7 @@
           <li class="nested-sidebar-item"><a href="../sessions/type-safe-session.html">Codable Routing Session</a></li>
         </ul>
         <li class="sidebar-item collapsible">Authentication</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../authentication/authentication.html">What is Authentication?</a></li>
           <li class="nested-sidebar-item"><a href="../authentication/typesafe-auth.html">Type-Safe Credentials</a></li>
           <li class="nested-sidebar-item"><a href="../authentication/jwt-auth.html">JSON Web Tokens</a></li>

--- a/docs/authentication/jwt-auth.html
+++ b/docs/authentication/jwt-auth.html
@@ -60,7 +60,7 @@
           <li class="nested-sidebar-item"><a href="../sessions/type-safe-session.html">Codable Routing Session</a></li>
         </ul>
         <li class="sidebar-item collapsible">Authentication</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../authentication/authentication.html">What is Authentication?</a></li>
           <li class="nested-sidebar-item"><a href="../authentication/typesafe-auth.html">Type-Safe Credentials</a></li>
           <li class="nested-sidebar-item active"><a href="../authentication/jwt-auth.html">JSON Web Tokens</a></li>

--- a/docs/authentication/jwt-auth.html
+++ b/docs/authentication/jwt-auth.html
@@ -60,7 +60,7 @@
           <li class="nested-sidebar-item"><a href="../sessions/type-safe-session.html">Codable Routing Session</a></li>
         </ul>
         <li class="sidebar-item collapsible">Authentication</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../authentication/authentication.html">What is Authentication?</a></li>
           <li class="nested-sidebar-item"><a href="../authentication/typesafe-auth.html">Type-Safe Credentials</a></li>
           <li class="nested-sidebar-item active"><a href="../authentication/jwt-auth.html">JSON Web Tokens</a></li>

--- a/docs/authentication/typesafe-auth.html
+++ b/docs/authentication/typesafe-auth.html
@@ -60,7 +60,7 @@
           <li class="nested-sidebar-item"><a href="../sessions/type-safe-session.html">Codable Routing Session</a></li>
         </ul>
         <li class="sidebar-item collapsible">Authentication</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../authentication/authentication.html">What is Authentication?</a></li>
           <li class="nested-sidebar-item active"><a href="../authentication/typesafe-auth.html">Type-Safe Credentials</a></li>
           <li class="nested-sidebar-item"><a href="../authentication/jwt-auth.html">JSON Web Tokens</a></li>

--- a/docs/authentication/typesafe-auth.html
+++ b/docs/authentication/typesafe-auth.html
@@ -60,7 +60,7 @@
           <li class="nested-sidebar-item"><a href="../sessions/type-safe-session.html">Codable Routing Session</a></li>
         </ul>
         <li class="sidebar-item collapsible">Authentication</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../authentication/authentication.html">What is Authentication?</a></li>
           <li class="nested-sidebar-item active"><a href="../authentication/typesafe-auth.html">Type-Safe Credentials</a></li>
           <li class="nested-sidebar-item"><a href="../authentication/jwt-auth.html">JSON Web Tokens</a></li>

--- a/docs/databases/couchdb.html
+++ b/docs/databases/couchdb.html
@@ -47,7 +47,7 @@
           <li class="nested-sidebar-item"><a href="../routing/open-api.html">OpenAPI</a></li>
         </ul>
         <li class="sidebar-item collapsible">Databases</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../databases/databases.html">What are Databases?</a></li>
           <li class="nested-sidebar-item"><a href="../databases/swift-kuery-orm.html">SQL: ORM</a></li>
           <li class="nested-sidebar-item"><a href="../databases/swift-kuery.html">SQL: Kuery</a></li>

--- a/docs/databases/couchdb.html
+++ b/docs/databases/couchdb.html
@@ -47,7 +47,7 @@
           <li class="nested-sidebar-item"><a href="../routing/open-api.html">OpenAPI</a></li>
         </ul>
         <li class="sidebar-item collapsible">Databases</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../databases/databases.html">What are Databases?</a></li>
           <li class="nested-sidebar-item"><a href="../databases/swift-kuery-orm.html">SQL: ORM</a></li>
           <li class="nested-sidebar-item"><a href="../databases/swift-kuery.html">SQL: Kuery</a></li>

--- a/docs/databases/databases.html
+++ b/docs/databases/databases.html
@@ -47,7 +47,7 @@
           <li class="nested-sidebar-item"><a href="../routing/open-api.html">OpenAPI</a></li>
         </ul>
         <li class="sidebar-item collapsible">Databases</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item active"><a href="../databases/databases.html">What are Databases?</a></li>
           <li class="nested-sidebar-item"><a href="../databases/swift-kuery-orm.html">SQL: ORM</a></li>
           <li class="nested-sidebar-item"><a href="../databases/swift-kuery.html">SQL: Kuery</a></li>

--- a/docs/databases/databases.html
+++ b/docs/databases/databases.html
@@ -47,7 +47,7 @@
           <li class="nested-sidebar-item"><a href="../routing/open-api.html">OpenAPI</a></li>
         </ul>
         <li class="sidebar-item collapsible">Databases</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item active"><a href="../databases/databases.html">What are Databases?</a></li>
           <li class="nested-sidebar-item"><a href="../databases/swift-kuery-orm.html">SQL: ORM</a></li>
           <li class="nested-sidebar-item"><a href="../databases/swift-kuery.html">SQL: Kuery</a></li>

--- a/docs/databases/swift-kuery-orm.html
+++ b/docs/databases/swift-kuery-orm.html
@@ -47,7 +47,7 @@
           <li class="nested-sidebar-item"><a href="../routing/open-api.html">OpenAPI</a></li>
         </ul>
         <li class="sidebar-item collapsible">Databases</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../databases/databases.html">What are Databases?</a></li>
           <li class="nested-sidebar-item active"><a href="../databases/swift-kuery-orm.html">SQL: ORM</a></li>
           <li class="nested-sidebar-item"><a href="../databases/swift-kuery.html">SQL: Kuery</a></li>

--- a/docs/databases/swift-kuery-orm.html
+++ b/docs/databases/swift-kuery-orm.html
@@ -47,7 +47,7 @@
           <li class="nested-sidebar-item"><a href="../routing/open-api.html">OpenAPI</a></li>
         </ul>
         <li class="sidebar-item collapsible">Databases</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../databases/databases.html">What are Databases?</a></li>
           <li class="nested-sidebar-item active"><a href="../databases/swift-kuery-orm.html">SQL: ORM</a></li>
           <li class="nested-sidebar-item"><a href="../databases/swift-kuery.html">SQL: Kuery</a></li>

--- a/docs/databases/swift-kuery.html
+++ b/docs/databases/swift-kuery.html
@@ -47,7 +47,7 @@
           <li class="nested-sidebar-item"><a href="../routing/open-api.html">OpenAPI</a></li>
         </ul>
         <li class="sidebar-item collapsible">Databases</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../databases/databases.html">What are Databases?</a></li>
           <li class="nested-sidebar-item"><a href="../databases/swift-kuery-orm.html">SQL: ORM</a></li>
           <li class="nested-sidebar-item active"><a href="../databases/swift-kuery.html">SQL: Kuery</a></li>

--- a/docs/databases/swift-kuery.html
+++ b/docs/databases/swift-kuery.html
@@ -47,7 +47,7 @@
           <li class="nested-sidebar-item"><a href="../routing/open-api.html">OpenAPI</a></li>
         </ul>
         <li class="sidebar-item collapsible">Databases</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../databases/databases.html">What are Databases?</a></li>
           <li class="nested-sidebar-item"><a href="../databases/swift-kuery-orm.html">SQL: ORM</a></li>
           <li class="nested-sidebar-item active"><a href="../databases/swift-kuery.html">SQL: Kuery</a></li>

--- a/docs/deploying/cloud-foundry.html
+++ b/docs/deploying/cloud-foundry.html
@@ -74,7 +74,7 @@
           <li class="nested-sidebar-item"><a href="../templating/markdown.html">Markdown</a></li>
         </ul>
         <li class="sidebar-item collapsible">Deploying</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../deploying/monitoring.html">Monitoring</a></li>
           <li class="nested-sidebar-item"><a href="../deploying/ssl.html">Enabling SSL/TLS</a></li>
           <li class="nested-sidebar-item"><a href="../deploying/docker.html">Docker</a></li>

--- a/docs/deploying/cloud-foundry.html
+++ b/docs/deploying/cloud-foundry.html
@@ -74,7 +74,7 @@
           <li class="nested-sidebar-item"><a href="../templating/markdown.html">Markdown</a></li>
         </ul>
         <li class="sidebar-item collapsible">Deploying</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../deploying/monitoring.html">Monitoring</a></li>
           <li class="nested-sidebar-item"><a href="../deploying/ssl.html">Enabling SSL/TLS</a></li>
           <li class="nested-sidebar-item"><a href="../deploying/docker.html">Docker</a></li>

--- a/docs/deploying/docker.html
+++ b/docs/deploying/docker.html
@@ -74,7 +74,7 @@
           <li class="nested-sidebar-item"><a href="../templating/markdown.html">Markdown</a></li>
         </ul>
         <li class="sidebar-item collapsible">Deploying</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../deploying/monitoring.html">Monitoring</a></li>
           <li class="nested-sidebar-item"><a href="../deploying/ssl.html">Enabling SSL/TLS</a></li>
           <li class="nested-sidebar-item active"><a href="../deploying/docker.html">Docker</a></li>

--- a/docs/deploying/docker.html
+++ b/docs/deploying/docker.html
@@ -74,7 +74,7 @@
           <li class="nested-sidebar-item"><a href="../templating/markdown.html">Markdown</a></li>
         </ul>
         <li class="sidebar-item collapsible">Deploying</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../deploying/monitoring.html">Monitoring</a></li>
           <li class="nested-sidebar-item"><a href="../deploying/ssl.html">Enabling SSL/TLS</a></li>
           <li class="nested-sidebar-item active"><a href="../deploying/docker.html">Docker</a></li>

--- a/docs/deploying/kubernetes.html
+++ b/docs/deploying/kubernetes.html
@@ -74,7 +74,7 @@
           <li class="nested-sidebar-item"><a href="../templating/markdown.html">Markdown</a></li>
         </ul>
         <li class="sidebar-item collapsible">Deploying</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../deploying/monitoring.html">Monitoring</a></li>
           <li class="nested-sidebar-item"><a href="../deploying/ssl.html">Enabling SSL/TLS</a></li>
           <li class="nested-sidebar-item"><a href="../deploying/docker.html">Docker</a></li>

--- a/docs/deploying/kubernetes.html
+++ b/docs/deploying/kubernetes.html
@@ -74,7 +74,7 @@
           <li class="nested-sidebar-item"><a href="../templating/markdown.html">Markdown</a></li>
         </ul>
         <li class="sidebar-item collapsible">Deploying</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../deploying/monitoring.html">Monitoring</a></li>
           <li class="nested-sidebar-item"><a href="../deploying/ssl.html">Enabling SSL/TLS</a></li>
           <li class="nested-sidebar-item"><a href="../deploying/docker.html">Docker</a></li>

--- a/docs/deploying/monitoring.html
+++ b/docs/deploying/monitoring.html
@@ -74,7 +74,7 @@
           <li class="nested-sidebar-item"><a href="../templating/markdown.html">Markdown</a></li>
         </ul>
         <li class="sidebar-item collapsible">Deploying</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item active"><a href="../deploying/monitoring.html">Monitoring</a></li>
           <li class="nested-sidebar-item"><a href="../deploying/ssl.html">Enabling SSL/TLS</a></li>
           <li class="nested-sidebar-item"><a href="../deploying/docker.html">Docker</a></li>

--- a/docs/deploying/monitoring.html
+++ b/docs/deploying/monitoring.html
@@ -74,7 +74,7 @@
           <li class="nested-sidebar-item"><a href="../templating/markdown.html">Markdown</a></li>
         </ul>
         <li class="sidebar-item collapsible">Deploying</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item active"><a href="../deploying/monitoring.html">Monitoring</a></li>
           <li class="nested-sidebar-item"><a href="../deploying/ssl.html">Enabling SSL/TLS</a></li>
           <li class="nested-sidebar-item"><a href="../deploying/docker.html">Docker</a></li>

--- a/docs/deploying/ssl.html
+++ b/docs/deploying/ssl.html
@@ -73,7 +73,7 @@
           <li class="nested-sidebar-item"><a href="../templating/markdown.html">Markdown</a></li>
         </ul>
         <li class="sidebar-item collapsible">Deploying</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../deploying/monitoring.html">Monitoring</a></li>
           <li class="nested-sidebar-item"><a href="../deploying/ssl.html">Enabling SSL/TLS</a></li>
           <li class="nested-sidebar-item"><a href="../deploying/docker.html">Docker</a></li>

--- a/docs/deploying/ssl.html
+++ b/docs/deploying/ssl.html
@@ -73,7 +73,7 @@
           <li class="nested-sidebar-item"><a href="../templating/markdown.html">Markdown</a></li>
         </ul>
         <li class="sidebar-item collapsible">Deploying</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../deploying/monitoring.html">Monitoring</a></li>
           <li class="nested-sidebar-item"><a href="../deploying/ssl.html">Enabling SSL/TLS</a></li>
           <li class="nested-sidebar-item"><a href="../deploying/docker.html">Docker</a></li>

--- a/docs/getting-started/create-server-app.html
+++ b/docs/getting-started/create-server-app.html
@@ -27,7 +27,7 @@
       <div class="underline-title"></div>
       <ul class="sidebar-list">
         <li class="sidebar-item collapsible">Getting Started</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../getting-started/installation-mac.html">Installation for macOS</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/installation-linux.html">Installation for Linux</a></li>
           <li class="nested-sidebar-item active"><a href="../getting-started/create-server.html">Create a server</a></li>

--- a/docs/getting-started/create-server-app.html
+++ b/docs/getting-started/create-server-app.html
@@ -27,7 +27,7 @@
       <div class="underline-title"></div>
       <ul class="sidebar-list">
         <li class="sidebar-item collapsible">Getting Started</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../getting-started/installation-mac.html">Installation for macOS</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/installation-linux.html">Installation for Linux</a></li>
           <li class="nested-sidebar-item active"><a href="../getting-started/create-server.html">Create a server</a></li>

--- a/docs/getting-started/create-server-cli.html
+++ b/docs/getting-started/create-server-cli.html
@@ -27,7 +27,7 @@
       <div class="underline-title"></div>
       <ul class="sidebar-list">
         <li class="sidebar-item collapsible">Getting Started</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../getting-started/installation-mac.html">Installation for macOS</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/installation-linux.html">Installation for Linux</a></li>
           <li class="nested-sidebar-item active"><a href="../getting-started/create-server.html">Create a server</a></li>

--- a/docs/getting-started/create-server-cli.html
+++ b/docs/getting-started/create-server-cli.html
@@ -27,7 +27,7 @@
       <div class="underline-title"></div>
       <ul class="sidebar-list">
         <li class="sidebar-item collapsible">Getting Started</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../getting-started/installation-mac.html">Installation for macOS</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/installation-linux.html">Installation for Linux</a></li>
           <li class="nested-sidebar-item active"><a href="../getting-started/create-server.html">Create a server</a></li>

--- a/docs/getting-started/create-server-spm.html
+++ b/docs/getting-started/create-server-spm.html
@@ -27,7 +27,7 @@
       <div class="underline-title"></div>
       <ul class="sidebar-list">
         <li class="sidebar-item collapsible">Getting Started</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../getting-started/installation-mac.html">Installation for macOS</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/installation-linux.html">Installation for Linux</a></li>
           <li class="nested-sidebar-item active"><a href="../getting-started/create-server.html">Create a server</a></li>

--- a/docs/getting-started/create-server-spm.html
+++ b/docs/getting-started/create-server-spm.html
@@ -27,7 +27,7 @@
       <div class="underline-title"></div>
       <ul class="sidebar-list">
         <li class="sidebar-item collapsible">Getting Started</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../getting-started/installation-mac.html">Installation for macOS</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/installation-linux.html">Installation for Linux</a></li>
           <li class="nested-sidebar-item active"><a href="../getting-started/create-server.html">Create a server</a></li>

--- a/docs/getting-started/create-server.html
+++ b/docs/getting-started/create-server.html
@@ -27,7 +27,7 @@
       <div class="underline-title"></div>
       <ul class="sidebar-list">
         <li class="sidebar-item collapsible">Getting Started</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../getting-started/installation-mac.html">Installation for macOS</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/installation-linux.html">Installation for Linux</a></li>
           <li class="nested-sidebar-item active"><a href="../getting-started/create-server.html">Create a server</a></li>

--- a/docs/getting-started/create-server.html
+++ b/docs/getting-started/create-server.html
@@ -27,7 +27,7 @@
       <div class="underline-title"></div>
       <ul class="sidebar-list">
         <li class="sidebar-item collapsible">Getting Started</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../getting-started/installation-mac.html">Installation for macOS</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/installation-linux.html">Installation for Linux</a></li>
           <li class="nested-sidebar-item active"><a href="../getting-started/create-server.html">Create a server</a></li>

--- a/docs/getting-started/installation-linux.html
+++ b/docs/getting-started/installation-linux.html
@@ -27,7 +27,7 @@
       <div class="underline-title"></div>
       <ul class="sidebar-list">
         <li class="sidebar-item collapsible">Getting Started</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../getting-started/installation-mac.html">Installation for macOS</a></li>
           <li class="nested-sidebar-item active"><a href="../getting-started/installation-linux.html">Installation for Linux</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/create-server.html">Create a server</a></li>

--- a/docs/getting-started/installation-linux.html
+++ b/docs/getting-started/installation-linux.html
@@ -27,7 +27,7 @@
       <div class="underline-title"></div>
       <ul class="sidebar-list">
         <li class="sidebar-item collapsible">Getting Started</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../getting-started/installation-mac.html">Installation for macOS</a></li>
           <li class="nested-sidebar-item active"><a href="../getting-started/installation-linux.html">Installation for Linux</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/create-server.html">Create a server</a></li>

--- a/docs/getting-started/installation-mac.html
+++ b/docs/getting-started/installation-mac.html
@@ -27,7 +27,7 @@
       <div class="underline-title"></div>
       <ul class="sidebar-list">
         <li class="sidebar-item collapsible">Getting Started</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item active"><a href="../getting-started/installation-mac.html">Installation for macOS</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/installation-linux.html">Installation for Linux</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/create-server.html">Create a server</a></li>

--- a/docs/getting-started/installation-mac.html
+++ b/docs/getting-started/installation-mac.html
@@ -27,7 +27,7 @@
       <div class="underline-title"></div>
       <ul class="sidebar-list">
         <li class="sidebar-item collapsible">Getting Started</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item active"><a href="../getting-started/installation-mac.html">Installation for macOS</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/installation-linux.html">Installation for Linux</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/create-server.html">Create a server</a></li>

--- a/docs/getting-started/style-guide.html
+++ b/docs/getting-started/style-guide.html
@@ -27,7 +27,7 @@
       <div class="underline-title"></div>
       <ul class="sidebar-list">
         <li class="sidebar-item collapsible">Getting Started</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../getting-started/installation-mac.html">Installation for macOS</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/installation-linux.html">Installation for Linux</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/create-server.html">Create a server</a></li>

--- a/docs/getting-started/style-guide.html
+++ b/docs/getting-started/style-guide.html
@@ -27,7 +27,7 @@
       <div class="underline-title"></div>
       <ul class="sidebar-list">
         <li class="sidebar-item collapsible">Getting Started</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../getting-started/installation-mac.html">Installation for macOS</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/installation-linux.html">Installation for Linux</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/create-server.html">Create a server</a></li>

--- a/docs/getting-started/test.html
+++ b/docs/getting-started/test.html
@@ -27,7 +27,7 @@
       <div class="underline-title"></div>
       <ul class="sidebar-list">
         <li class="sidebar-item collapsible">Getting Started</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../getting-started/installation-mac.html">Installation for macOS</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/installation-linux.html">Installation for Linux</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/create-server.html">Create a server</a></li>

--- a/docs/getting-started/test.html
+++ b/docs/getting-started/test.html
@@ -27,7 +27,7 @@
       <div class="underline-title"></div>
       <ul class="sidebar-list">
         <li class="sidebar-item collapsible">Getting Started</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../getting-started/installation-mac.html">Installation for macOS</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/installation-linux.html">Installation for Linux</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/create-server.html">Create a server</a></li>

--- a/docs/getting-started/update-package.html
+++ b/docs/getting-started/update-package.html
@@ -27,7 +27,7 @@
       <div class="underline-title"></div>
       <ul class="sidebar-list">
         <li class="sidebar-item collapsible">Getting Started</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../getting-started/installation-mac.html">Installation for macOS</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/installation-linux.html">Installation for Linux</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/create-server.html">Create a server</a></li>

--- a/docs/getting-started/update-package.html
+++ b/docs/getting-started/update-package.html
@@ -27,7 +27,7 @@
       <div class="underline-title"></div>
       <ul class="sidebar-list">
         <li class="sidebar-item collapsible">Getting Started</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../getting-started/installation-mac.html">Installation for macOS</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/installation-linux.html">Installation for Linux</a></li>
           <li class="nested-sidebar-item"><a href="../getting-started/create-server.html">Create a server</a></li>

--- a/docs/logging/helium-logger.html
+++ b/docs/logging/helium-logger.html
@@ -35,7 +35,7 @@
           <li class="nested-sidebar-item"><a href="../getting-started/update-package.html">Adding Packages</a></li>
         </ul>
         <li class="sidebar-item collapsible">Logging</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../logging/logging.html">What is Logging?</a></li>
           <li class="nested-sidebar-item active"><a href="../logging/helium-logger.html">Helium Logger</a></li>
         </ul>

--- a/docs/logging/helium-logger.html
+++ b/docs/logging/helium-logger.html
@@ -35,7 +35,7 @@
           <li class="nested-sidebar-item"><a href="../getting-started/update-package.html">Adding Packages</a></li>
         </ul>
         <li class="sidebar-item collapsible">Logging</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../logging/logging.html">What is Logging?</a></li>
           <li class="nested-sidebar-item active"><a href="../logging/helium-logger.html">Helium Logger</a></li>
         </ul>

--- a/docs/logging/logging.html
+++ b/docs/logging/logging.html
@@ -35,7 +35,7 @@
           <li class="nested-sidebar-item"><a href="../getting-started/update-package.html">Adding Packages</a></li>
         </ul>
         <li class="sidebar-item collapsible">Logging</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item active"><a href="../logging/logging.html">What is Logging?</a></li>
           <li class="nested-sidebar-item"><a href="../logging/helium-logger.html">Helium Logger</a></li>
         </ul>

--- a/docs/logging/logging.html
+++ b/docs/logging/logging.html
@@ -35,7 +35,7 @@
           <li class="nested-sidebar-item"><a href="../getting-started/update-package.html">Adding Packages</a></li>
         </ul>
         <li class="sidebar-item collapsible">Logging</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item active"><a href="../logging/logging.html">What is Logging?</a></li>
           <li class="nested-sidebar-item"><a href="../logging/helium-logger.html">Helium Logger</a></li>
         </ul>

--- a/docs/routing/codable-routing.html
+++ b/docs/routing/codable-routing.html
@@ -40,7 +40,7 @@
           <li class="nested-sidebar-item"><a href="../logging/helium-logger.html">Helium Logger</a></li>
         </ul>
         <li class="sidebar-item collapsible">Routing</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../routing/routing.html">What is routing?</a></li>
           <li class="nested-sidebar-item active"><a href="../routing/codable-routing.html">Codable routing</a></li>
           <li class="nested-sidebar-item"><a href="../routing/raw-routing.html">Raw routing</a></li>

--- a/docs/routing/codable-routing.html
+++ b/docs/routing/codable-routing.html
@@ -40,7 +40,7 @@
           <li class="nested-sidebar-item"><a href="../logging/helium-logger.html">Helium Logger</a></li>
         </ul>
         <li class="sidebar-item collapsible">Routing</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../routing/routing.html">What is routing?</a></li>
           <li class="nested-sidebar-item active"><a href="../routing/codable-routing.html">Codable routing</a></li>
           <li class="nested-sidebar-item"><a href="../routing/raw-routing.html">Raw routing</a></li>

--- a/docs/routing/open-api.html
+++ b/docs/routing/open-api.html
@@ -40,7 +40,7 @@
           <li class="nested-sidebar-item"><a href="../logging/helium-logger.html">Helium Logger</a></li>
         </ul>
         <li class="sidebar-item collapsible">Routing</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../routing/routing.html">What is routing?</a></li>
           <li class="nested-sidebar-item"><a href="../routing/codable-routing.html">Codable routing</a></li>
           <li class="nested-sidebar-item"><a href="../routing/raw-routing.html">Raw routing</a></li>

--- a/docs/routing/open-api.html
+++ b/docs/routing/open-api.html
@@ -40,7 +40,7 @@
           <li class="nested-sidebar-item"><a href="../logging/helium-logger.html">Helium Logger</a></li>
         </ul>
         <li class="sidebar-item collapsible">Routing</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../routing/routing.html">What is routing?</a></li>
           <li class="nested-sidebar-item"><a href="../routing/codable-routing.html">Codable routing</a></li>
           <li class="nested-sidebar-item"><a href="../routing/raw-routing.html">Raw routing</a></li>

--- a/docs/routing/raw-routing.html
+++ b/docs/routing/raw-routing.html
@@ -40,7 +40,7 @@
           <li class="nested-sidebar-item"><a href="../logging/helium-logger.html">Helium Logger</a></li>
         </ul>
         <li class="sidebar-item collapsible">Routing</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../routing/routing.html">What is routing?</a></li>
           <li class="nested-sidebar-item"><a href="../routing/codable-routing.html">Codable routing</a></li>
           <li class="nested-sidebar-item active"><a href="../routing/raw-routing.html">Raw routing</a></li>

--- a/docs/routing/raw-routing.html
+++ b/docs/routing/raw-routing.html
@@ -40,7 +40,7 @@
           <li class="nested-sidebar-item"><a href="../logging/helium-logger.html">Helium Logger</a></li>
         </ul>
         <li class="sidebar-item collapsible">Routing</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../routing/routing.html">What is routing?</a></li>
           <li class="nested-sidebar-item"><a href="../routing/codable-routing.html">Codable routing</a></li>
           <li class="nested-sidebar-item active"><a href="../routing/raw-routing.html">Raw routing</a></li>

--- a/docs/routing/routing.html
+++ b/docs/routing/routing.html
@@ -40,7 +40,7 @@
           <li class="nested-sidebar-item"><a href="../logging/helium-logger.html">Helium Logger</a></li>
         </ul>
         <li class="sidebar-item collapsible">Routing</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item active"><a href="../routing/routing.html">What is routing?</a></li>
           <li class="nested-sidebar-item"><a href="../routing/codable-routing.html">Codable routing</a></li>
           <li class="nested-sidebar-item"><a href="../routing/raw-routing.html">Raw routing</a></li>

--- a/docs/routing/routing.html
+++ b/docs/routing/routing.html
@@ -40,7 +40,7 @@
           <li class="nested-sidebar-item"><a href="../logging/helium-logger.html">Helium Logger</a></li>
         </ul>
         <li class="sidebar-item collapsible">Routing</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item active"><a href="../routing/routing.html">What is routing?</a></li>
           <li class="nested-sidebar-item"><a href="../routing/codable-routing.html">Codable routing</a></li>
           <li class="nested-sidebar-item"><a href="../routing/raw-routing.html">Raw routing</a></li>

--- a/docs/sessions/kitura-session.html
+++ b/docs/sessions/kitura-session.html
@@ -54,7 +54,7 @@
           <li class="nested-sidebar-item"><a href="../databases/couchdb.html">NoSQL: CouchDB</a></li>
         </ul>
         <li class="sidebar-item collapsible">Sessions</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../sessions/sessions.html">What are Sessions?</a></li>
           <li class="nested-sidebar-item active"><a href="../sessions/kitura-session.html">Raw Routing Session</a></li>
           <li class="nested-sidebar-item"><a href="../sessions/type-safe-session.html">Codable Routing Session</a></li>

--- a/docs/sessions/kitura-session.html
+++ b/docs/sessions/kitura-session.html
@@ -54,7 +54,7 @@
           <li class="nested-sidebar-item"><a href="../databases/couchdb.html">NoSQL: CouchDB</a></li>
         </ul>
         <li class="sidebar-item collapsible">Sessions</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../sessions/sessions.html">What are Sessions?</a></li>
           <li class="nested-sidebar-item active"><a href="../sessions/kitura-session.html">Raw Routing Session</a></li>
           <li class="nested-sidebar-item"><a href="../sessions/type-safe-session.html">Codable Routing Session</a></li>

--- a/docs/sessions/sessions.html
+++ b/docs/sessions/sessions.html
@@ -54,7 +54,7 @@
           <li class="nested-sidebar-item"><a href="../databases/couchdb.html">NoSQL: CouchDB</a></li>
         </ul>
         <li class="sidebar-item collapsible">Sessions</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item active"><a href="../sessions/sessions.html">What are Sessions?</a></li>
           <li class="nested-sidebar-item"><a href="../sessions/kitura-session.html">Raw Routing Session</a></li>
           <li class="nested-sidebar-item"><a href="../sessions/type-safe-session.html">Codable Routing Session</a></li>

--- a/docs/sessions/sessions.html
+++ b/docs/sessions/sessions.html
@@ -54,7 +54,7 @@
           <li class="nested-sidebar-item"><a href="../databases/couchdb.html">NoSQL: CouchDB</a></li>
         </ul>
         <li class="sidebar-item collapsible">Sessions</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item active"><a href="../sessions/sessions.html">What are Sessions?</a></li>
           <li class="nested-sidebar-item"><a href="../sessions/kitura-session.html">Raw Routing Session</a></li>
           <li class="nested-sidebar-item"><a href="../sessions/type-safe-session.html">Codable Routing Session</a></li>

--- a/docs/sessions/type-safe-session.html
+++ b/docs/sessions/type-safe-session.html
@@ -54,7 +54,7 @@
           <li class="nested-sidebar-item"><a href="../databases/couchdb.html">NoSQL: CouchDB</a></li>
         </ul>
         <li class="sidebar-item collapsible">Sessions</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../sessions/sessions.html">What are Sessions?</a></li>
           <li class="nested-sidebar-item"><a href="../sessions/kitura-session.html">Raw Routing Session</a></li>
           <li class="nested-sidebar-item active"><a href="../sessions/type-safe-session.html">Codable Routing Session</a></li>

--- a/docs/sessions/type-safe-session.html
+++ b/docs/sessions/type-safe-session.html
@@ -54,7 +54,7 @@
           <li class="nested-sidebar-item"><a href="../databases/couchdb.html">NoSQL: CouchDB</a></li>
         </ul>
         <li class="sidebar-item collapsible">Sessions</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../sessions/sessions.html">What are Sessions?</a></li>
           <li class="nested-sidebar-item"><a href="../sessions/kitura-session.html">Raw Routing Session</a></li>
           <li class="nested-sidebar-item active"><a href="../sessions/type-safe-session.html">Codable Routing Session</a></li>

--- a/docs/templating/markdown.html
+++ b/docs/templating/markdown.html
@@ -67,7 +67,7 @@
           <li class="nested-sidebar-item"><a href="../authentication/fb-google-oauth2.html">OAuth 2.0 with Facebook/Google</a></li>
         </ul>
         <li class="sidebar-item collapsible">Web Application</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../templating/templating.html">What is templating?</a></li>
           <li class="nested-sidebar-item"><a href="../templating/static-file-server.html">Static File Server</a></li>
           <li class="nested-sidebar-item"><a href="../templating/stencil.html">Stencil</a></li>

--- a/docs/templating/markdown.html
+++ b/docs/templating/markdown.html
@@ -67,7 +67,7 @@
           <li class="nested-sidebar-item"><a href="../authentication/fb-google-oauth2.html">OAuth 2.0 with Facebook/Google</a></li>
         </ul>
         <li class="sidebar-item collapsible">Web Application</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../templating/templating.html">What is templating?</a></li>
           <li class="nested-sidebar-item"><a href="../templating/static-file-server.html">Static File Server</a></li>
           <li class="nested-sidebar-item"><a href="../templating/stencil.html">Stencil</a></li>

--- a/docs/templating/static-file-server.html
+++ b/docs/templating/static-file-server.html
@@ -66,7 +66,7 @@
           <li class="nested-sidebar-item"><a href="../authentication/fb-google-oauth2.html">OAuth 2.0 with Facebook/Google</a></li>
         </ul>
         <li class="sidebar-item collapsible">Web Application</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../templating/templating.html">What is templating?</a></li>
           <li class="nested-sidebar-item active"><a href="../templating/static-file-server.html">Static File Server</a></li>
           <li class="nested-sidebar-item"><a href="../templating/stencil.html">Stencil</a></li>

--- a/docs/templating/static-file-server.html
+++ b/docs/templating/static-file-server.html
@@ -66,7 +66,7 @@
           <li class="nested-sidebar-item"><a href="../authentication/fb-google-oauth2.html">OAuth 2.0 with Facebook/Google</a></li>
         </ul>
         <li class="sidebar-item collapsible">Web Application</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../templating/templating.html">What is templating?</a></li>
           <li class="nested-sidebar-item active"><a href="../templating/static-file-server.html">Static File Server</a></li>
           <li class="nested-sidebar-item"><a href="../templating/stencil.html">Stencil</a></li>

--- a/docs/templating/stencil.html
+++ b/docs/templating/stencil.html
@@ -67,7 +67,7 @@
           <li class="nested-sidebar-item"><a href="../authentication/fb-google-oauth2.html">OAuth 2.0 with Facebook/Google</a></li>
         </ul>
         <li class="sidebar-item collapsible">Web Application</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item"><a href="../templating/templating.html">What is templating?</a></li>
           <li class="nested-sidebar-item"><a href="../templating/static-file-server.html">Static File Server</a></li>
           <li class="nested-sidebar-item active"><a href="../templating/stencil.html">Stencil</a></li>

--- a/docs/templating/stencil.html
+++ b/docs/templating/stencil.html
@@ -67,7 +67,7 @@
           <li class="nested-sidebar-item"><a href="../authentication/fb-google-oauth2.html">OAuth 2.0 with Facebook/Google</a></li>
         </ul>
         <li class="sidebar-item collapsible">Web Application</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item"><a href="../templating/templating.html">What is templating?</a></li>
           <li class="nested-sidebar-item"><a href="../templating/static-file-server.html">Static File Server</a></li>
           <li class="nested-sidebar-item active"><a href="../templating/stencil.html">Stencil</a></li>

--- a/docs/templating/templating.html
+++ b/docs/templating/templating.html
@@ -67,7 +67,7 @@
           <li class="nested-sidebar-item"><a href="../authentication/fb-google-oauth2.html">OAuth 2.0 with Facebook/Google</a></li>
         </ul>
         <li class="sidebar-item collapsible">Web Application</li>
-        <ul class="nested-sidebar-list content" style="max-height: 100%">
+        <ul class="nested-sidebar-list content" style="max-height: 250px;">
           <li class="nested-sidebar-item active"><a href="../templating/templating.html">What is templating?</a></li>
           <li class="nested-sidebar-item"><a href="../templating/static-file-server.html">Static File Server</a></li>
           <li class="nested-sidebar-item"><a href="../templating/stencil.html">Stencil</a></li>

--- a/docs/templating/templating.html
+++ b/docs/templating/templating.html
@@ -67,7 +67,7 @@
           <li class="nested-sidebar-item"><a href="../authentication/fb-google-oauth2.html">OAuth 2.0 with Facebook/Google</a></li>
         </ul>
         <li class="sidebar-item collapsible">Web Application</li>
-        <ul class="nested-sidebar-list content">
+        <ul class="nested-sidebar-list content" style="max-height: 100%">
           <li class="nested-sidebar-item active"><a href="../templating/templating.html">What is templating?</a></li>
           <li class="nested-sidebar-item"><a href="../templating/static-file-server.html">Static File Server</a></li>
           <li class="nested-sidebar-item"><a href="../templating/stencil.html">Stencil</a></li>


### PR DESCRIPTION
This pull request adds a default height to the sidebar page that is open so that when you click a link the sidebar doesn't collapse back down.

it is set to 250px however if a sidebar gets larger than this the value will need to be increased