### PR TITLE
Update Kitura-NIO API link in packages.html

### DIFF
--- a/packages.html
+++ b/packages.html
@@ -212,7 +212,7 @@ gtag('config', 'UA-73924704-2', { 'anonymize_ip': true });
           <h4><a href="https://github.com/IBM-Swift/Kitura-net">Kitura-net</a></h4><a href="https://ibm-swift.github.io/Kitura-net/"><h5>API</h5></a>
           <p>Logic for sending and receiving HTTP requests.</p>
 
-          <h4><a href="https://github.com/IBM-Swift/Kitura-NIO">Kitura-NIO</a></h4><a href="https://developer.ibm.com/swift/2018/05/31/introducing-kitura-nio/"><h5>BETA</h5></a>
+          <h4><a href="https://github.com/IBM-Swift/Kitura-NIO">Kitura-NIO</a></h4><a href="https://ibm-swift.github.io/Kitura-NIO/"><h5>API</h5></a>
           <p>Logic for sending and receiving HTTP requests using Apple's SwiftNIO framework.</p>
 
           <h4><a href="https://github.com/IBM-Swift/KituraContracts">Kitura Contracts</a></h4><a href="https://ibm-swift.github.io/KituraContracts/"><h5>API</h5></a>


### PR DESCRIPTION
 - The Kitura-NIO docs are now available. Linking them from the packages.html
 - I'm unsure if the BETA tag should be changed to API (do we call it `BETA` until Kitura-NIO isn't default).

cc @helenmasters @ddunn2 