### PR TITLE
Address review comments for authentication guides

### DIFF
--- a/docs/authentication/jwt-auth.html
+++ b/docs/authentication/jwt-auth.html
@@ -449,7 +449,12 @@ extension App {
          If we want to use JWTs on our codable routes, we need to encapulate the verification and creation of the users JWT in a <strong>TypeSafeMiddleware</strong>.
      We can then register our <strong>TypeSafeMiddleware</strong> on a Codable route to authenticate the user and access their claims.</p>
     <h2 class="heading-2"><span class="blue-text">Step 9a:</span> Define our type safe middleware.</h2>
-    <p>Create a new file called <strong>TypeSafeJWT.swift</strong> in <strong>Sources</strong> > <strong>Application</strong> > <strong>Middlewares</strong></p>
+    <p>If you don't already have one, create a <strong>Middlewares</strong> folder:</p>
+    <pre><code>mkdir Sources/Application/Middlewares</code></pre>
+    <p>Create a new file, called <strong>TypeSafeJWT.swift</strong>:</p>
+    <pre><code>touch Sources/Application/Middlewares/TypeSafeJWT.swift</code></pre>
+    <p>Open your <strong>TypeSafeJWT.swift</strong> file:</p>
+    <pre><code>open Sources/Application/Middlewares/TypeSafeJWT.swift</code></pre>
     <p>Inside this file, define <strong>TypeSafeJWT</strong> with the following code:</p>
 <pre><code class="language-swift">import SwiftJWT
 import Kitura

--- a/docs/authentication/jwt-auth.html
+++ b/docs/authentication/jwt-auth.html
@@ -281,7 +281,7 @@ mwIDAQAB
          This could be achieved with basic authentication, the Authorization header or in the body of a POST request.
          In this guide we will pass the username and password in the body of a POST request and use a model to represent this.</p>
          <div class="info">
-           <p>Passwords and signed JWTs must be kept private and should always be exchanged over a secure layer like HTTPS.</p>
+           <p>Passwords and JWTs with sensitive data must be kept private and should always be exchanged over a secure layer like HTTPS.</p>
          </div>
         <p>Create a new file, called <strong>UserCredentials.swift</strong>:</p>
         <pre><code>touch Sources/Application/Models/UserCredentials.swift</code></pre>
@@ -330,7 +330,7 @@ mwIDAQAB
     // Users credentials are authenticated
     let myClaims = ClaimsStandardJWT(iss: "Kitura", sub: credentials.username, exp: Date(timeIntervalSinceNow: 3600))
     var myJWT = JWT(claims: myClaims)
-    let signedJWT = try myJWT.sign(using: App.signer)
+    let signedJWT = try myJWT.sign(using: App.jwtSigner)
     response.send(signedJWT)
     next()
 }</code></pre>
@@ -348,7 +348,7 @@ mwIDAQAB
 }'</code></pre>
 <p>You should be returned a JWT string that is structured <strong>xxxx.yyyy.zzzz</strong>
      where xxxx is the base64 encoded header, yyyy is the base 64 encoded claims and zzzz is the signature.</p>
-<p>Below is an example JWT, generated using <strong>HS256</strong> and the password "kitura":<p>
+<p>Below is an example JWT, generated using <strong>HS256</strong> with the password "kitura". The one returned by your curl request will have different values but the same structure.<p>
 <pre><code>eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJLaXR1cmEiLCJzdWIiOiJKb2UgQmxvZ2dzIiwiZXhwIjoxNTUzMDE4Mjg0LjMyOTcwMTl9.t55WealACtYGCQGS3EQgRQuurmNSBO5fWZqzqJjEIi</code></pre>
 <p>We can decode the JWT string using the debugger at <a href="https://jwt.io/#debugger" rel="noopener" target="_blank">JWT.IO</a> which allows us view the headers and claims.</p>
     <div class="underline"></div>

--- a/docs/authentication/typesafe-auth.html
+++ b/docs/authentication/typesafe-auth.html
@@ -107,7 +107,7 @@
         <p class="block-text">In this guide, we use <a target="_blank" href="https://github.com/IBM-Swift/Kitura-CredentialsHTTP"> Kitura-CredentialsHTTP</a> to add HTTP basic authentication to Codable routes.</p>
         <div class="underline"></div>
         <h2 class="heading-2"><span class="blue-text">Step 1:</span> Define the authentication middleware</h2>
-        <p>To add basic authentication to our server, we need to <a target="_blank" href="https://github.com/IBM-Swift/Kitura-CredentialsHTTP"> add Kitura-CredentialsHTTP to our dependencies</a>.</p>
+        <p>To add basic authentication to our server, we need to <a target="_blank" href="https://github.com/IBM-Swift/Kitura-CredentialsHTTP#add-dependencies"> add Kitura-CredentialsHTTP to our dependencies</a>.</p>
         <div class="info">
             <p>If you don't have a server, follow our <a target="_blank" href="https://www.kitura.io/docs/getting-started/create-server.html"> Create a server</a> guide.</p>
         </div>

--- a/docs/authentication/typesafe-auth.html
+++ b/docs/authentication/typesafe-auth.html
@@ -113,6 +113,8 @@
         </div>
         <p>Next, we will define a <strong>TypeSafeMiddleware</strong> which conforms to <strong>TypeSafeHTTPBasic</strong>.</p>
         <p>This will be initialized when our route is successfully authenticated and we will be able to access the authenticated user's id within our Codable route.</p>
+        <p>If you don't already have one, create a <strong>Middlewares</strong> folder:</p>
+        <pre><code>mkdir Sources/Application/Middlewares</code></pre>
         <p>Create a new file, called <strong>MyBasicAuth.swift</strong>:</p>
         <pre><code>touch Sources/Application/Middlewares/MyBasicAuth.swift</code></pre>
         <p>Open your <strong>MyBasicAuth.swift</strong> file:</p>

--- a/docs/databases/swift-kuery.html
+++ b/docs/databases/swift-kuery.html
@@ -337,7 +337,7 @@ class BookTable: Table {
     let price = Column("price", Float.self)
     let genre = Column("genre", String.self)
 }</code></pre>
-        <p class="block-text">This class represents our <strong>Book</strong> model as an SQL table.
+        <p class="block-text">The <strong>BookTable</strong> class represents our <strong>Book</strong> model as an SQL table.
           It needs to inherit from <strong>Table</strong> and match the column names of the table we created in the database.
           We must also provide the table name as a property.</p>
         <p>Return to the <strong>KueryRoutes.swift</strong> file. In the <strong>App</strong> extension, create an instance of this table:</p>

--- a/docs/sessions/type-safe-session.html
+++ b/docs/sessions/type-safe-session.html
@@ -142,6 +142,8 @@ extension App {
         <h2 class="heading-2"><span class="blue-text bold">Step 2:</span> Define your Session</h2>
         <p>To use sessions with Codable routes, we need to model the structure of what we will store in the session.
            We do this by defining a Swift type that conforms to the <strong>TypeSafeSession</strong> protocol.</p>
+        <p>If you don't already have one, create a <strong>Middlewares</strong> folder:</p>
+        <pre><code>mkdir Sources/Application/Middlewares</code></pre>
         <p>Create a new file, called <strong>CheckoutSession.swift</strong>:</p>
         <pre><code>touch Sources/Application/Middlewares/CheckoutSession.swift</code></pre>
         <p>Open your <strong>CheckoutSession.swift</strong> file:</p>


### PR DESCRIPTION
- There is now a [pull request](https://github.com/IBM-Swift/Kitura-CredentialsHTTP/pull/60) to credentialsHTTP adding a usage guide which is being pointed at
- I have added a line for creating the middlewares folder if it doesn't already exist
- We do need a raw routing Basic authentication guide and issue #132 exists to track this
- JWT typo causing compile error has been fixed
- We decided to keep the single complete example at the end for simplicity. When the website changed the toggle system will probably change as well so this can be addressed then
- Oauth2 failure is tracked in the issue you linked