### PR TITLE
Address review comments from sessions walkthrough

### DIFF
--- a/docs/sessions/kitura-session.html
+++ b/docs/sessions/kitura-session.html
@@ -120,7 +120,11 @@
          <pre><code>open Sources/Application/Application.swift</code></pre>
          <p> Inside the <strong>postInit()</strong> function add: </p>
          <pre><code class="language-swift">initializeSessionRawRoutes(app: self)</code></pre>
-         <p>Next, create a new file, called <strong>SessionRawRoutes.swift</strong>, to contain the framework for our routes code:</p>
+         <p>Create a new file called <strong>SessionRawRoutes.swift</strong> to define the session routes in:</p>
+         <pre><code>touch Sources/Application/Routes/SessionRawRoutes.swift</code></pre>
+         <p>Open the <strong>SessionRawRoutes.swift</strong> file:</p>
+         <pre><code>open Sources/Application/Routes/SessionRawRoutes.swift</code></pre>
+         <p>Inside this file we will add the code for our session routes:</p>
          <pre><code class="language-swift">import KituraSession
 
 func initializeSessionRawRoutes(app: App) {

--- a/docs/sessions/type-safe-session.html
+++ b/docs/sessions/type-safe-session.html
@@ -146,9 +146,6 @@ extension App {
         <pre><code>touch Sources/Application/Middlewares/CheckoutSession.swift</code></pre>
         <p>Open your <strong>CheckoutSession.swift</strong> file:</p>
         <pre><code>open Sources/Application/Middlewares/CheckoutSession.swift</code></pre>
-        <div class="info">
-          <p>You may need to create the <strong>Middlewares</strong> folder.</p>
-        </div>
         <p>We can use either a class or a struct for <strong>TypeSafeMiddleware</strong> here but we will use a Class.</p>
         <p>Inside this file, define your <strong>CheckoutSession</strong> class:</p>
         <pre><code class="language-swift">import KituraSession
@@ -225,21 +222,41 @@ extension App {
         completion(session.books, nil)
     }
 }</code></pre>
-        <p>The easiest way to test that this works is using <a onclick="setActiveSidebarElementForParent('openapi')" href="../routing/open-api.html#">Kitura OpenAPI</a>.</p>
         <div class="underline"></div>
         <h2 class="heading-2"><span class="blue-text">Step 5:</span> Test our Session</h2>
-        <p>We will be using Kitura OpenAPI to test our sessions but any tool capable of testing APIs, such as <a href="https://www.getpostman.com/">Postman</a>, would work.</p>
-        <div class="info">
-          <p>If you don't know how to test your Codable routes using Kiura OpenAPI then you can follow our <a onclick="setActiveSidebarElementForParent('openapi')" href="../routing/open-api.html#">Kitura OpenAPI Guide</a> to learn how.</p>
-        </div>
-        <p>To use OpenAPI we first need to start our server.</p>
-        <p>Once the server has started open:</p>
-        <p><a target="_blank" href="http://localhost:8080/openapi/ui">http://localhost:8080/openapi/ui</a></p>
-        <p>Use OpenAPI to post a books to "/cart"</p>
-        <p>To test the GET, either use OpenAPI or go to <a target="_blank" href="http://localhost:8080/cart">http://localhost:8080/cart</a>.</p>
-        <p>You should see the book you posted. The server is using cookies to make a unique response for your session.</p>
-        <p>You can test this by opening a private window and going to <a target="_blank" href="http://localhost:8080/cart">http://localhost:8080/cart</a>.
-           This will make a new session and the cart will be empty.</p>
+        <p>An easy way to test our our session is using <a onclick="setActiveSidebarElementForParent('openapi')" href="../routing/open-api.html#">Kitura OpenAPI</a>.
+        You can follow our <a onclick="setActiveSidebarElementForParent('openapi')" href="../routing/open-api.html#">Kitura OpenAPI Guide</a> to learn how to set up OpenAPI and use the interface for testing.</p>
+        <p>Alternatively, we can test our routes by sending a request using curl, with cookies enabled.</p>
+        <p>Open Terminal and enter the following:</p>
+        <pre><code>curl -X POST \
+http://localhost:8080/cart \
+-b cookies.txt -c cookies.txt \
+-H 'content-type: application/json' \
+-d '{
+    "id": 1,
+    "title": "War and Peace",
+    "price": 10.99,
+    "genre": "Historical drama"
+}'</code></pre>
+        <p>If our request was successful, our book will be returned to us:</p>
+        <pre><code>{"id":1,"title":"War and Peace","price":10.99,"genre":"Historical drama"}</code></pre>
+        <p>We will also have a cookie that curl has stored in the <strong>cookies.txt</strong> file.</p>
+        <p>To retrieve our book, we make another curl request to our server:</p>
+        <pre><code>curl -X GET \
+http://localhost:8080/cart \
+-b cookies.txt -c cookies.txt</code></pre>
+    <p>If the request is successful, it will return the book we just sent to the server.</p>
+    <pre><code>[{"id":1,"title":"War and Peace","price":10.99,"genre":"Historical drama"}]</code></pre>
+    <p>The cookie we sent with our request has identifed our session, so that our saved book can be returned.</p>
+    <p>Each user making requests to these routes will create their own basket of books.</p>
+    <p>We can demonstrate this by deleting our cookie:</p>
+    <pre><code>rm cookies.txt</code></pre>
+    <p>Followed by making a new GET request:</p>
+    <pre><code>curl -X GET \
+http://localhost:8080/cart \
+-b cookies.txt -c cookies.txt</code></pre>
+    <p>This represents a user without a session so we are returned an empty array:</p>
+    <pre><code>[]</code></pre>
         <div class="underline"></div>
         <h2 class="heading-2">Next steps</h2>
         <p><span class="blue-text bold"><a onclick="setActiveSidebarElementForParent('typesafe-auth')" href="../authentication/typesafe-auth.html#">Authentication:</a></span> Learn about authentication and what Kitura provides.</p>


### PR DESCRIPTION
- The "Unlike the session cookies are stored client-side" was fixed in an earlier pr
- Create folder instructions have been added
- The testing code from Raw sessions has been moved over to test using Curl. A comment linking to OpenAPI guide for testing was left in if somebody would like to use OpenAPI for testing.