### PR TITLE
Update the Markdown guide

### DIFF
--- a/docs/templating/markdown.html
+++ b/docs/templating/markdown.html
@@ -104,32 +104,63 @@
       <main>
         <h1 class="heading-1">Kitura Markdown</h1>
         <p>In this guide, we will show you how to serve a web page generated from <a target="_blank" href="https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet"> Markdown templates</a> (.md files) using <a target="_blank" href="https://github.com/IBM-Swift/Kitura-Markdown"> Kitura-Markdown</a>.</p>
-        <h2 class="heading-2"><span class="blue-text">Step 1:</span> Add KituraMarkdown to the Kitura App</h2>
+        <h2 class="heading-2"><span class="blue-text">Step 1:</span> Add KituraMarkdown to Project</h2>
         <p>To use Markdown from a server, we first need to <a target="_blank" href="https://github.com/IBM-Swift/Kitura-Markdown#add-dependencies"> add Kitura-Markdown to our dependencies</a>.</p>
         <div class="info">
             <p>If you don't have a server, follow our <a target="_blank" href="https://www.kitura.io/docs/getting-started/create-server.html"> Create a server</a> guide.</p>
         </div>
-        <p>Next, we need to import the KituraMarkdown package:</p>
-        <pre><code class="language-swift">import KituraMarkdown</code></pre>
+        <p>Next, we need to import the KituraMarkdown package.</p>
         <p>Open your <strong>Application.swift</strong> file:</p>
         <pre><code>open Sources/Application/Application.swift</code></pre>
+        <p>Then at the top of the file add the import statement for KituraMarkdown:</p>
+        <pre><code class="language-swift">import KituraMarkdown</code></pre>
+        <p>Now we can register the KituraMarkdown Template Engine to our router instance.</p>
         <p>Inside the <strong>postInit()</strong> function add: </p>
         <pre><code class="language-swift">router.add(templateEngine: KituraMarkdown())</code></pre>
-        <p>This tells the server that on this instance of the router we'd like to use the KituraMarkdown template engine.</p>
         <div class="info">
           <p>Kitura supports multiple template engines being registered to a single instance of a router. By default each templating engine will handle files in the <strong>./Views</strong> directory that match the file extension it supports.</p>
         </div>
-        <p>We've just added the KituraMarkdown template engine to our router, so now we can use it in a route.</p>
-        <p>Just below our other registered routes we can create a new route for KituraMarkdown:</p>
-        <pre><code class="language-swift">router.get("/book") { request, response, next in
-    try response.render("book.md", context: [:])
-}</code></pre>
-        <p>The <strong>response.render()</strong> method attempts to populate the provided template file with the provided data.</p>
-        <p>However, as we are rendering a Markdown file the <strong>context</strong> parameter is ignored.</p>
-        <p>So in our case KituraMarkdown will take the <strong>book.md</strong> file and render the Markdown in it to be viewed in a browser.</p>
-        <p>This obviously will not work as we haven't created our <strong>book.md</strong> file.</p>
         <div class="underline"></div>
-        <h2 class="heading-2"><span class="blue-text bold">Step 2:</span> Create the template file</h2>
+        <h2 class="heading-2"><span class="blue-text">Step 2:</span> Configure KituraMarkdown</h2>
+        <p>By default KituraMarkdown will just render our Markdown to their corresponding HTML elements without allowing us to set any HTML properties, such as the configuration found in the <strong>&lt;head&gt;</strong> tag.</p>
+        <p>We can provide an HTML wrapper template for our rendered Markdown using MarkdownOptions.</p>
+        <p>Inside the <strong>postInit()</strong> function we add:</p>
+        <pre><code class="language-swift">let markdownOptions = MarkdownOptions(pageTemplate: "default")</code></pre>
+        <p>We have selected the default template which provides the following HTML wrapper:</p>
+        <pre><code>&lt;!DOCTYPE html&gt;
+&lt;html lang=\"en\"&gt;
+  &lt;head&gt;
+    &lt;meta charset=\"UTF-8\"&gt;
+  &lt;/head&gt;
+  &lt;body&gt;
+    &lt;div&gt;
+      &lt;snippetInsertLocation&gt;&lt;/snippetInsertLocation&gt;
+    &lt;/div&gt;
+  &lt;/body&gt;
+&lt;/html&gt;
+        </code></pre>
+        <p>During the rendering of the Markdown file, the rendered string replaces the <strong>&lt;snippetInsertLocation&gt;&lt;/snippetInsertLocation&gt;</strong> tag.</p>
+        <div class="info">
+          <p>Here we used a default template however you can provide your own template using the MarkdownOptions:</p>
+          <pre><code class="language-swift">let markdownOptions = MarkdownOptions(pageTemplate: """
+&lt;!DOCTYPE html&gt;
+&lt;html lang=\"en\"&gt;
+    &lt;head&gt;
+        &lt;meta charset=\"UTF-8\"&gt;
+    &lt;/head&gt;
+    &lt;body&gt;
+        &lt;div&gt;
+            &lt;h1&gt;My Page Title&lt;/h1&gt;
+        &lt;/div&gt;
+        &lt;div&gt;
+            &lt;snippetInsertLocation&gt;&lt;/snippetInsertLocation&gt;
+        &lt;/div&gt;
+    &lt;/body&gt;
+&lt;/html&gt;
+""")</code></pre>
+        </div>
+        <div class="underline"></div>
+        <h2 class="heading-2"><span class="blue-text bold">Step 3:</span> Create the template file</h2>
         <p>By default, Kitura looks for template files in a <strong>./Views</strong> directory found at the root of the project.</p>
         <div class="info">
           <p>Typically the root of your project is where the <strong>.xcodeproj</strong> directory is.</p>
@@ -147,16 +178,26 @@
           <pre><code>swift package generate-xcodeproj</code></pre>
           <p>This is to enable Xcode to detect the new directory.</p>
         </div>
-        <div class="underline"></div>
-        <h2 class="heading-2"><span class="blue-text bold">Step 3:</span> Populate the Markdown template file</h2>
-        <p>First we need some Markdown to render.</p>
-        <p>So in the <strong>book.md</strong> file we will add:</p>
+        <p>Now we can add some Markdown to render:</p>
+        <p>So in the <strong>book.md</strong> file add:</p>
         <pre><code># Books Header
 
 Description with **bold** text
 
 * Book1
 * Book2</code></pre>
+        <div class="underline"></div>
+        <h2 class="heading-2"><span class="blue-text bold">Step 4:</span> Render the Markdown</h2>
+        <p>We've just added the KituraMarkdown template engine to our router, so now we can use it in a route.</p>
+        <p>Just below our other registered routes we can create a new route for KituraMarkdown:</p>
+        <pre><code class="language-swift">router.get("/book") { request, response, next in
+    try response.render("book.md", context: [:], options: markdownOptions))
+}</code></pre>
+        <div class="info">
+          <p>You will notice a <strong>context</strong> parameter is required however as Markdown files provide all the context this value is ignored so we simply pass in an empty context.</p>
+        </div>
+        <p>The <strong>response.render()</strong> method attempts to populate the provided template file with the provided data.</p>
+        <p>So in our case KituraMarkdown will take the <strong>book.md</strong> file and render the Markdown in it to be viewed in a browser.</p>     
         <p>Now to test our templating we first need to start the Kitura server.</p>
         <p>Then in a brower we can open:</p>
         <p><a target="_blank" href="http://localhost:8080/book">http://localhost:8080/book</a></p>

--- a/docs/templating/markdown.html
+++ b/docs/templating/markdown.html
@@ -122,7 +122,7 @@
         </div>
         <div class="underline"></div>
         <h2 class="heading-2"><span class="blue-text">Step 2:</span> Configure KituraMarkdown</h2>
-        <p>By default KituraMarkdown will render our Markdown to their corresponding HTML elements without allowing us to set any HTML properties, such as the configuration found in the <strong>&lt;head&gt;</strong> tag.</p>
+        <p>We may wish to provide a custom configuration for these properties, for example, to configure the contents of the <strong>&lt;head&gt;</strong> tag. To do this we can provide a HTML wrapper template for our rendered Markdown using MarkdownOptions.</p>
         <p>To provide this configuration we can provide a HTML wrapper template for our rendered Markdown using MarkdownOptions.</p>
         <p>Inside the <strong>postInit()</strong> function add:</p>
         <pre><code class="language-swift">let markdownOptions = MarkdownOptions(pageTemplate: "default")</code></pre>
@@ -140,7 +140,7 @@
       &lt;/body&gt;
     &lt;/html&gt;
             </code></pre>
-            <p>Alternatively you can provide your own template using the MarkdownOptions:</p>
+            <p>Alternatively you can provide your own template using MarkdownOptions:</p>
             <pre><code class="language-swift">let markdownOptions = MarkdownOptions(pageTemplate: """
   &lt;!DOCTYPE html&gt;
   &lt;html lang=\"en\"&gt;
@@ -188,15 +188,15 @@ Description with **bold** text
 * Book2</code></pre>
         <div class="underline"></div>
         <h2 class="heading-2"><span class="blue-text bold">Step 4:</span> Render the Markdown</h2>
-        <p>We've just added the KituraMarkdown template engine to our router, so now we can use it in a route.</p>
+        <p>We've added the KituraMarkdown template engine to our router, so now we can use it in a route.</p>
         <p>Just below our other registered routes we can create a new route for KituraMarkdown:</p>
         <pre><code class="language-swift">router.get("/book") { request, response, next in
     try response.render("book.md", context: [:], options: markdownOptions))
 }</code></pre>
         <div class="info">
-          <p>You will notice a <strong>context</strong> parameter is required however as Markdown files provide all the context this value is ignored so we simply pass in an empty context.</p>
+          <p>You will notice a <strong>context</strong> parameter is required, however as Markdown files provide all the context this value is ignored, so we simply pass in an empty context.</p>
         </div>
-        <p>The <strong>response.render()</strong> method attempts to populate the provided template file with the provided data.</p>
+        <p>The <strong>response.render()</strong> method attempts to populate the template file with the provided data.</p>
         <p>So in our case KituraMarkdown will take the <strong>book.md</strong> file and render the Markdown in it to be viewed in a browser.</p>     
         <p>Now to test our templating we first need to start the Kitura server.</p>
         <p>Then in a brower we can open:</p>

--- a/docs/templating/markdown.html
+++ b/docs/templating/markdown.html
@@ -122,43 +122,43 @@
         </div>
         <div class="underline"></div>
         <h2 class="heading-2"><span class="blue-text">Step 2:</span> Configure KituraMarkdown</h2>
-        <p>By default KituraMarkdown will just render our Markdown to their corresponding HTML elements without allowing us to set any HTML properties, such as the configuration found in the <strong>&lt;head&gt;</strong> tag.</p>
-        <p>We can provide an HTML wrapper template for our rendered Markdown using MarkdownOptions.</p>
-        <p>Inside the <strong>postInit()</strong> function we add:</p>
+        <p>By default KituraMarkdown will render our Markdown to their corresponding HTML elements without allowing us to set any HTML properties, such as the configuration found in the <strong>&lt;head&gt;</strong> tag.</p>
+        <p>To provide this configuration we can provide a HTML wrapper template for our rendered Markdown using MarkdownOptions.</p>
+        <p>Inside the <strong>postInit()</strong> function add:</p>
         <pre><code class="language-swift">let markdownOptions = MarkdownOptions(pageTemplate: "default")</code></pre>
-        <p>We have selected the default template which provides the following HTML wrapper:</p>
-        <pre><code>&lt;!DOCTYPE html&gt;
-&lt;html lang=\"en\"&gt;
-  &lt;head&gt;
-    &lt;meta charset=\"UTF-8\"&gt;
-  &lt;/head&gt;
-  &lt;body&gt;
-    &lt;div&gt;
-      &lt;snippetInsertLocation&gt;&lt;/snippetInsertLocation&gt;
-    &lt;/div&gt;
-  &lt;/body&gt;
-&lt;/html&gt;
-        </code></pre>
-        <p>During the rendering of the Markdown file, the rendered string replaces the <strong>&lt;snippetInsertLocation&gt;&lt;/snippetInsertLocation&gt;</strong> tag.</p>
-        <div class="info">
-          <p>Here we used a default template however you can provide your own template using the MarkdownOptions:</p>
-          <pre><code class="language-swift">let markdownOptions = MarkdownOptions(pageTemplate: """
-&lt;!DOCTYPE html&gt;
-&lt;html lang=\"en\"&gt;
-    &lt;head&gt;
+        <div class=info>
+            <p>We have selected the default template which provides the following HTML wrapper:</p>
+            <pre><code>&lt;!DOCTYPE html&gt;
+    &lt;html lang=\"en\"&gt;
+      &lt;head&gt;
         &lt;meta charset=\"UTF-8\"&gt;
-    &lt;/head&gt;
-    &lt;body&gt;
+      &lt;/head&gt;
+      &lt;body&gt;
         &lt;div&gt;
-            &lt;h1&gt;My Page Title&lt;/h1&gt;
+          &lt;snippetInsertLocation&gt;&lt;/snippetInsertLocation&gt;
         &lt;/div&gt;
-        &lt;div&gt;
-            &lt;snippetInsertLocation&gt;&lt;/snippetInsertLocation&gt;
-        &lt;/div&gt;
-    &lt;/body&gt;
-&lt;/html&gt;
-""")</code></pre>
+      &lt;/body&gt;
+    &lt;/html&gt;
+            </code></pre>
+            <p>Alternatively you can provide your own template using the MarkdownOptions:</p>
+            <pre><code class="language-swift">let markdownOptions = MarkdownOptions(pageTemplate: """
+  &lt;!DOCTYPE html&gt;
+  &lt;html lang=\"en\"&gt;
+      &lt;head&gt;
+          &lt;meta charset=\"UTF-8\"&gt;
+      &lt;/head&gt;
+      &lt;body&gt;
+          &lt;div&gt;
+              &lt;h1&gt;My Page Title&lt;/h1&gt;
+          &lt;/div&gt;
+          &lt;div&gt;
+              &lt;snippetInsertLocation&gt;&lt;/snippetInsertLocation&gt;
+          &lt;/div&gt;
+      &lt;/body&gt;
+  &lt;/html&gt;
+  """)</code></pre>
         </div>
+        <p>During the rendering of the Markdown file, our rendered Markdown content replaces the <strong>&lt;snippetInsertLocation&gt;&lt;/snippetInsertLocation&gt;</strong> tag.</p>
         <div class="underline"></div>
         <h2 class="heading-2"><span class="blue-text bold">Step 3:</span> Create the template file</h2>
         <p>By default, Kitura looks for template files in a <strong>./Views</strong> directory found at the root of the project.</p>

--- a/docs/templating/markdown.html
+++ b/docs/templating/markdown.html
@@ -122,7 +122,7 @@
         </div>
         <div class="underline"></div>
         <h2 class="heading-2"><span class="blue-text">Step 2:</span> Configure KituraMarkdown</h2>
-        <p>We may wish to provide a custom configuration for these properties, for example, to configure the contents of the <strong>&lt;head&gt;</strong> tag. To do this we can provide a HTML wrapper template for our rendered Markdown using MarkdownOptions.</p>
+        <p>We may wish to provide a custom configuration for these properties, for example, to configure the contents of the <strong>&lt;head&gt;</strong> tag.</p>
         <p>To provide this configuration we can provide a HTML wrapper template for our rendered Markdown using MarkdownOptions.</p>
         <p>Inside the <strong>postInit()</strong> function add:</p>
         <pre><code class="language-swift">let markdownOptions = MarkdownOptions(pageTemplate: "default")</code></pre>


### PR DESCRIPTION
Currently the Markdown guide doesn't describe how to use the `MarkdownOptions` parameter. 

This parameter for the render method enables users to provide a HTML wrapper for their Markdown content, which should be expressed in the guide. 

This PR adds this configuration to the Markdown Guide. 