### PR TITLE
Add Travis and gh-pages deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ before_script:
   - npm install -g gatsby-cli
 node_js:
   - "10"
+script:
+  - cd website/ && npm test
 deploy:
   provider: script
   # Note: change "website" to the directory where your gatsby-site lives, if necessary

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+before_script:
+  - npm install -g gatsby-cli
+node_js:
+  - "10"
+deploy:
+  provider: script
+  # Note: change "website" to the directory where your gatsby-site lives, if necessary
+  script: cd website/ && yarn install && yarn run deploy
+  skip_cleanup: true
+  on:
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ before_script:
 node_js:
   - "10"
 script:
-  - cd website/ && npm test
+  - cd ${TRAVIS_BUILD_DIR}/website/ && npm test
 deploy:
   provider: script
   # Note: change "website" to the directory where your gatsby-site lives, if necessary
-  script: cd website/ && yarn install && yarn run deploy
+  script: cd ${TRAVIS_BUILD_DIR}/website/ && yarn install && yarn run deploy
   skip_cleanup: true
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 before_script:
-  - npm install -g gatsby-cli
+  - npm install -g gatsby-cli gh-pages
 node_js:
   - "10"
 script:

--- a/website/package.json
+++ b/website/package.json
@@ -19,6 +19,7 @@
     "react-dom": "^16.8.6"
   },
   "scripts": {
+    "test": "echo 'TODO: add tests'",
     "deploy": "gatsby build --prefix-paths && gh-pages -d public -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -17,5 +17,8 @@
     "react": "^16.8.6",
     "react-collapsible": "^2.6.0",
     "react-dom": "^16.8.6"
+  },
+  "scripts": {
+    "deploy": "gatsby build --prefix-paths && gh-pages -d public -r https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git"
   }
 }


### PR DESCRIPTION
This PR adds a `.travis,yml` for building and deploying the site using `gh-pages`.

Upon merging a PR to master, `gatsby build` will be invoked, followed by `gh-pages`, resulting in the website being published to the `gh-pages` branch.

Resolves #411 

## Prereqs

Before merging `updateWebsite` to master, the Travis configuration must have a suitable Github access token defined in a `GH_TOKEN` env var.

## After merging

The current configuration of Github Pages serves `/docs` from the master branch.  This needs to be changed to serve the `gh-pages` branch instead.