### PR TITLE
Custom claims: Fix CredentialsJWT options

### DIFF
--- a/content/docs/guides/authentication/jwt.md
+++ b/content/docs/guides/authentication/jwt.md
@@ -375,7 +375,7 @@ struct MyDelegate: UserProfileDelegate {
 Then we need to declare our instance of CredentialsJWT with our newly defined options, as well as setting the `subject` claim to `id`:
 
 ```swift
-let jwtCredentials = CredentialsJWT<MyClaims>(verifier: App.jwtVerifier, options: [CredentialsJWTOptions.subject: "id", CredentialsJWTOptions.userProfileDelegate: MyDelegate.self])
+let jwtCredentials = CredentialsJWT<MyClaims>(verifier: App.jwtVerifier, options: [CredentialsJWTOptions.subject: "id", CredentialsJWTOptions.userProfileDelegate: MyDelegate()])
 ```
 
 Finally we create our middleware and register our plugin to it, the same as we have done earlier:


### PR DESCRIPTION
Pass an instance of the delegate rather than the type.